### PR TITLE
パッケージのスコープと名称を変更します

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,26 +21,33 @@
         "@babel/highlight": "^7.12.13"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.0.tgz",
+      "integrity": "sha512-mKgFbYQ+23pjwNGBNPNWrBfa3g/EcmrPnwQpjWoNxq9xYf+M8wcLhMlz/wkWimLjzNzGnl3D+C2186gMzk0VuA==",
+      "dev": true
+    },
     "node_modules/@babel/core": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.17.tgz",
-      "integrity": "sha512-V3CuX1aBywbJvV2yzJScRxeiiw0v2KZZYYE3giywxzFJL13RiyPjaaDwhDnxmgFTTS7FgvM2ijr4QmKNIu0AtQ==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.1.tgz",
+      "integrity": "sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.17",
-        "@babel/helper-module-transforms": "^7.12.17",
-        "@babel/helpers": "^7.12.17",
-        "@babel/parser": "^7.12.17",
+        "@babel/generator": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helpers": "^7.13.0",
+        "@babel/parser": "^7.13.0",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.17",
-        "@babel/types": "^7.12.17",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
+        "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "semver": "^5.4.1",
+        "semver": "7.0.0",
         "source-map": "^0.5.0"
       },
       "engines": {
@@ -61,12 +68,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.17.tgz",
-      "integrity": "sha512-DSA7ruZrY4WI8VxuS1jWSRezFnghEoYEFrZcw9BizQRmOZiUsiHl59+qEARGPqPikwA/GPTyRCi7isuCK/oyqg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
+      "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.17",
+        "@babel/types": "^7.13.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -78,6 +85,21 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz",
+      "integrity": "sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.13.0",
+        "@babel/helper-validator-option": "^7.12.17",
+        "browserslist": "^4.14.5",
+        "semver": "7.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
@@ -101,12 +123,12 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.17.tgz",
-      "integrity": "sha512-Bzv4p3ODgS/qpBE0DiJ9qf5WxSmrQ8gVTe8ClMfwwsY2x/rhykxxy3bXzG7AGTnPB2ij37zGJ/Q/6FruxHxsxg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
+      "integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.17"
+        "@babel/types": "^7.13.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
@@ -119,19 +141,19 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.17.tgz",
-      "integrity": "sha512-sFL+p6zOCQMm9vilo06M4VHuTxUAwa6IxgL56Tq1DVtA0ziAGTH1ThmJq7xwPqdQlgAbKX3fb0oZNbtRIyA5KQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
+      "integrity": "sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.13.0",
         "@babel/helper-simple-access": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.12.11",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.17",
-        "@babel/types": "^7.12.17",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "lodash": "^4.17.19"
       }
     },
@@ -145,21 +167,21 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.12.13.tgz",
-      "integrity": "sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
       "dev": true
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz",
-      "integrity": "sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
+      "integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.12.13",
+        "@babel/helper-member-expression-to-functions": "^7.13.0",
         "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
@@ -186,15 +208,21 @@
       "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
       "dev": true
     },
-    "node_modules/@babel/helpers": {
+    "node_modules/@babel/helper-validator-option": {
       "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.17.tgz",
-      "integrity": "sha512-tEpjqSBGt/SFEsFikKds1sLNChKKGGR17flIgQKXH4fG6m9gTgl3gnOC1giHNyaBCSKuTfxaSzHi7UnvqiVKxg==",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+      "dev": true
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
+      "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.17",
-        "@babel/types": "^7.12.17"
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "node_modules/@babel/highlight": {
@@ -280,9 +308,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.17.tgz",
-      "integrity": "sha512-r1yKkiUTYMQ8LiEI0UcQx5ETw5dpTLn9wijn9hk6KkTtOK95FndDN10M+8/s6k/Ymlbivw0Av9q4SlgF80PtHg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.0.tgz",
+      "integrity": "sha512-w80kxEMFhE3wjMOQkfdTvv0CSdRSJZptIlLhU4eU/coNJeWjduspUFz+IRnBbAq6m5XYBFMoT1TNkk9K9yf10g==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -447,26 +475,26 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.17.tgz",
-      "integrity": "sha512-LGkTqDqdiwC6Q7fWSwQoas/oyiEYw6Hqjve5KOSykXkmFJFqzvGMb9niaUEag3Rlve492Mkye3gLw9FTv94fdQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
+      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.17",
+        "@babel/generator": "^7.13.0",
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.12.17",
-        "@babel/types": "^7.12.17",
+        "@babel/parser": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.17.tgz",
-      "integrity": "sha512-tNMDjcv/4DIcHxErTgwB9q2ZcYyN0sUfgGKUK/mm1FJK7Wz+KstoEekxrl/tBiNDgLK1HGi+sppj1An/1DR4fQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
+      "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -758,15 +786,15 @@
         "node": ">= 10.14.2"
       }
     },
-    "node_modules/@pico2map/map-editor": {
+    "node_modules/@piyoppi/pico2map-editor": {
       "resolved": "packages/map-editor",
       "link": true
     },
-    "node_modules/@pico2map/map-editor-samples": {
+    "node_modules/@piyoppi/pico2map-samples": {
       "resolved": "packages/map-editor-examples",
       "link": true
     },
-    "node_modules/@pico2map/tiled-map": {
+    "node_modules/@piyoppi/pico2map-tiled": {
       "resolved": "packages/tiled-map",
       "link": true
     },
@@ -1628,9 +1656,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001190",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001190.tgz",
-      "integrity": "sha512-62KVw474IK8E+bACBYhRS0/L6o/1oeAVkpF2WetjV58S5vkzNh0/Rz3lD8D4YCbOTqi0/aD4X3LtoP7V5xnuAg==",
+      "version": "1.0.30001191",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz",
+      "integrity": "sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==",
       "dev": true
     },
     "node_modules/capture-exit": {
@@ -2122,9 +2150,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.671",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.671.tgz",
-      "integrity": "sha512-RTD97QkdrJKaKwRv9h/wGAaoR2lGxNXEcBXS31vjitgTPwTWAbLdS7cEsBK68eEQy7p6YyT8D5BxBEYHu2SuwQ==",
+      "version": "1.3.672",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.672.tgz",
+      "integrity": "sha512-gFQe7HBb0lbOMqK2GAS5/1F+B0IMdYiAgB9OT/w1F4M7lgJK2aNOMNOM622aEax+nS1cTMytkiT0uMOkbtFmHw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2223,9 +2251,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.26.tgz",
-      "integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.0.tgz",
+      "integrity": "sha512-iuEGihqqhKWFgh72Q/Jtch7V2t/ft8w8IPP2aEN8ArYKO+IWyo6hsi96hCdgyeEDQIV3InhYQ9BlwUFPGXrbEQ==",
       "dev": true
     },
     "node_modules/escalade": {
@@ -4159,9 +4187,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "node_modules/lodash.sortby": {
@@ -4453,6 +4481,15 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/normalize-path": {
@@ -5475,6 +5512,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/sane/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/sane/node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -5552,12 +5598,12 @@
       }
     },
     "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
       "dev": true,
       "bin": {
-        "semver": "bin/semver"
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/serialize-javascript": {
@@ -6441,21 +6487,6 @@
         "typescript": ">=3.8 <5.0"
       }
     },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ts-loader": {
       "version": "8.0.17",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.17.tgz",
@@ -6787,9 +6818,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.23.0.tgz",
-      "integrity": "sha512-RC6dwDuRxiU75F8XC4H08NtzUrMfufw5LDnO8dTtaKU2+fszEdySCgZhNwSBBn516iNaJbQI7T7OPHIgCwcJmg==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.24.0.tgz",
+      "integrity": "sha512-ZkDxabL/InAQy9jluQTA8VIB7Gkhsv5uMJdAIz4QP2u4zaOX6+Tig7Jv+WSwhHp9qTnAx0rmn0dVTUPqZGRLbg==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
@@ -6801,7 +6832,7 @@
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.7.0",
-        "es-module-lexer": "^0.3.26",
+        "es-module-lexer": "^0.4.0",
         "eslint-scope": "^5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
@@ -7158,9 +7189,9 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.5.tgz",
-      "integrity": "sha512-jYRGS3zWy20NtDtK2kBgo/TlAoy5YUuhD9/LZ7z7W4j1Fdw2cqD0xEEclf8fxc8xjD6X5Qr+qQQwCEsP8iRiYg==",
+      "version": "20.2.6",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
+      "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -7199,7 +7230,7 @@
         "typescript": "^4.1.3"
       },
       "devDependencies": {
-        "@pico2map/tiled-map": "0.0.1",
+        "@piyoppi/pico2map-tiled": "0.0.1",
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3",
         "ts-jest": "^26.4.4",
@@ -7212,8 +7243,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@pico2map/map-editor": "0.0.1",
-        "@pico2map/tiled-map": "0.0.1",
+        "@piyoppi/pico2map-editor": "0.0.1",
+        "@piyoppi/pico2map-tiled": "0.0.1",
         "typescript": "^4.1.3"
       },
       "devDependencies": {
@@ -7248,26 +7279,33 @@
         "@babel/highlight": "^7.12.13"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.0.tgz",
+      "integrity": "sha512-mKgFbYQ+23pjwNGBNPNWrBfa3g/EcmrPnwQpjWoNxq9xYf+M8wcLhMlz/wkWimLjzNzGnl3D+C2186gMzk0VuA==",
+      "dev": true
+    },
     "@babel/core": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.17.tgz",
-      "integrity": "sha512-V3CuX1aBywbJvV2yzJScRxeiiw0v2KZZYYE3giywxzFJL13RiyPjaaDwhDnxmgFTTS7FgvM2ijr4QmKNIu0AtQ==",
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.1.tgz",
+      "integrity": "sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.17",
-        "@babel/helper-module-transforms": "^7.12.17",
-        "@babel/helpers": "^7.12.17",
-        "@babel/parser": "^7.12.17",
+        "@babel/generator": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helpers": "^7.13.0",
+        "@babel/parser": "^7.13.0",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.17",
-        "@babel/types": "^7.12.17",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.1",
+        "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "semver": "^5.4.1",
+        "semver": "7.0.0",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -7280,12 +7318,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.17.tgz",
-      "integrity": "sha512-DSA7ruZrY4WI8VxuS1jWSRezFnghEoYEFrZcw9BizQRmOZiUsiHl59+qEARGPqPikwA/GPTyRCi7isuCK/oyqg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
+      "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.17",
+        "@babel/types": "^7.13.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -7296,6 +7334,18 @@
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz",
+      "integrity": "sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.13.0",
+        "@babel/helper-validator-option": "^7.12.17",
+        "browserslist": "^4.14.5",
+        "semver": "7.0.0"
       }
     },
     "@babel/helper-function-name": {
@@ -7319,12 +7369,12 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.17.tgz",
-      "integrity": "sha512-Bzv4p3ODgS/qpBE0DiJ9qf5WxSmrQ8gVTe8ClMfwwsY2x/rhykxxy3bXzG7AGTnPB2ij37zGJ/Q/6FruxHxsxg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
+      "integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.17"
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/helper-module-imports": {
@@ -7337,19 +7387,19 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.17.tgz",
-      "integrity": "sha512-sFL+p6zOCQMm9vilo06M4VHuTxUAwa6IxgL56Tq1DVtA0ziAGTH1ThmJq7xwPqdQlgAbKX3fb0oZNbtRIyA5KQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
+      "integrity": "sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.12.13",
+        "@babel/helper-replace-supers": "^7.13.0",
         "@babel/helper-simple-access": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.12.11",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.17",
-        "@babel/types": "^7.12.17",
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "lodash": "^4.17.19"
       }
     },
@@ -7363,21 +7413,21 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.12.13.tgz",
-      "integrity": "sha512-C+10MXCXJLiR6IeG9+Wiejt9jmtFpxUc3MQqCmPY8hfCjyUGl9kT+B2okzEZrtykiwrc4dbCPdDoz0A/HQbDaA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
       "dev": true
     },
     "@babel/helper-replace-supers": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.13.tgz",
-      "integrity": "sha512-pctAOIAMVStI2TMLhozPKbf5yTEXc0OJa0eENheb4w09SrgOWEs+P4nTOZYJQCqs8JlErGLDPDJTiGIp3ygbLg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
+      "integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.12.13",
+        "@babel/helper-member-expression-to-functions": "^7.13.0",
         "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/helper-simple-access": {
@@ -7404,15 +7454,21 @@
       "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
       "dev": true
     },
-    "@babel/helpers": {
+    "@babel/helper-validator-option": {
       "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.17.tgz",
-      "integrity": "sha512-tEpjqSBGt/SFEsFikKds1sLNChKKGGR17flIgQKXH4fG6m9gTgl3gnOC1giHNyaBCSKuTfxaSzHi7UnvqiVKxg==",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+      "integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
+      "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.12.17",
-        "@babel/types": "^7.12.17"
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/highlight": {
@@ -7485,9 +7541,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.17.tgz",
-      "integrity": "sha512-r1yKkiUTYMQ8LiEI0UcQx5ETw5dpTLn9wijn9hk6KkTtOK95FndDN10M+8/s6k/Ymlbivw0Av9q4SlgF80PtHg==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.0.tgz",
+      "integrity": "sha512-w80kxEMFhE3wjMOQkfdTvv0CSdRSJZptIlLhU4eU/coNJeWjduspUFz+IRnBbAq6m5XYBFMoT1TNkk9K9yf10g==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -7610,26 +7666,26 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.17.tgz",
-      "integrity": "sha512-LGkTqDqdiwC6Q7fWSwQoas/oyiEYw6Hqjve5KOSykXkmFJFqzvGMb9niaUEag3Rlve492Mkye3gLw9FTv94fdQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
+      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.12.17",
+        "@babel/generator": "^7.13.0",
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.12.17",
-        "@babel/types": "^7.12.17",
+        "@babel/parser": "^7.13.0",
+        "@babel/types": "^7.13.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       }
     },
     "@babel/types": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.17.tgz",
-      "integrity": "sha512-tNMDjcv/4DIcHxErTgwB9q2ZcYyN0sUfgGKUK/mm1FJK7Wz+KstoEekxrl/tBiNDgLK1HGi+sppj1An/1DR4fQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
+      "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -7870,10 +7926,10 @@
         "chalk": "^4.0.0"
       }
     },
-    "@pico2map/map-editor": {
+    "@piyoppi/pico2map-editor": {
       "version": "file:packages/map-editor",
       "requires": {
-        "@pico2map/tiled-map": "0.0.1",
+        "@piyoppi/pico2map-tiled": "0.0.1",
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3",
         "lit-element": "^2.4.0",
@@ -7884,18 +7940,18 @@
         "webpack-cli": "^4.4.0"
       }
     },
-    "@pico2map/map-editor-samples": {
+    "@piyoppi/pico2map-samples": {
       "version": "file:packages/map-editor-examples",
       "requires": {
-        "@pico2map/map-editor": "0.0.1",
-        "@pico2map/tiled-map": "0.0.1",
+        "@piyoppi/pico2map-editor": "0.0.1",
+        "@piyoppi/pico2map-tiled": "0.0.1",
         "ts-loader": "^8.0.12",
         "typescript": "^4.1.3",
         "webpack": "^5.10.3",
         "webpack-cli": "^4.2.0"
       }
     },
-    "@pico2map/tiled-map": {
+    "@piyoppi/pico2map-tiled": {
       "version": "file:packages/tiled-map",
       "requires": {
         "@types/jest": "^26.0.20",
@@ -8636,9 +8692,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001190",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001190.tgz",
-      "integrity": "sha512-62KVw474IK8E+bACBYhRS0/L6o/1oeAVkpF2WetjV58S5vkzNh0/Rz3lD8D4YCbOTqi0/aD4X3LtoP7V5xnuAg==",
+      "version": "1.0.30001191",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz",
+      "integrity": "sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==",
       "dev": true
     },
     "capture-exit": {
@@ -9035,9 +9091,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.671",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.671.tgz",
-      "integrity": "sha512-RTD97QkdrJKaKwRv9h/wGAaoR2lGxNXEcBXS31vjitgTPwTWAbLdS7cEsBK68eEQy7p6YyT8D5BxBEYHu2SuwQ==",
+      "version": "1.3.672",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.672.tgz",
+      "integrity": "sha512-gFQe7HBb0lbOMqK2GAS5/1F+B0IMdYiAgB9OT/w1F4M7lgJK2aNOMNOM622aEax+nS1cTMytkiT0uMOkbtFmHw==",
       "dev": true
     },
     "emittery": {
@@ -9112,9 +9168,9 @@
       }
     },
     "es-module-lexer": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.3.26.tgz",
-      "integrity": "sha512-Va0Q/xqtrss45hWzP8CZJwzGSZJjDM5/MJRE3IXXnUCcVLElR9BRaE9F62BopysASyc4nM3uwhSW7FFB9nlWAA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.4.0.tgz",
+      "integrity": "sha512-iuEGihqqhKWFgh72Q/Jtch7V2t/ft8w8IPP2aEN8ArYKO+IWyo6hsi96hCdgyeEDQIV3InhYQ9BlwUFPGXrbEQ==",
       "dev": true
     },
     "escalade": {
@@ -10617,9 +10673,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.sortby": {
@@ -10858,6 +10914,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -11655,6 +11719,12 @@
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
         "shebang-command": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -11712,9 +11782,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
       "dev": true
     },
     "serialize-javascript": {
@@ -12418,17 +12488,6 @@
         "mkdirp": "1.x",
         "semver": "7.x",
         "yargs-parser": "20.x"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "ts-loader": {
@@ -12694,9 +12753,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.23.0.tgz",
-      "integrity": "sha512-RC6dwDuRxiU75F8XC4H08NtzUrMfufw5LDnO8dTtaKU2+fszEdySCgZhNwSBBn516iNaJbQI7T7OPHIgCwcJmg==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.24.0.tgz",
+      "integrity": "sha512-ZkDxabL/InAQy9jluQTA8VIB7Gkhsv5uMJdAIz4QP2u4zaOX6+Tig7Jv+WSwhHp9qTnAx0rmn0dVTUPqZGRLbg==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",
@@ -12708,7 +12767,7 @@
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.7.0",
-        "es-module-lexer": "^0.3.26",
+        "es-module-lexer": "^0.4.0",
         "eslint-scope": "^5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
@@ -12972,9 +13031,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.5.tgz",
-      "integrity": "sha512-jYRGS3zWy20NtDtK2kBgo/TlAoy5YUuhD9/LZ7z7W4j1Fdw2cqD0xEEclf8fxc8xjD6X5Qr+qQQwCEsP8iRiYg==",
+      "version": "20.2.6",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
+      "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
       "dev": true
     },
     "yocto-queue": {

--- a/packages/map-editor-examples/autotile/README.md
+++ b/packages/map-editor-examples/autotile/README.md
@@ -28,8 +28,8 @@ The AutoTile format is shown below.
 ```
 
 ```ts
-import { Projects } from '@pico2map/map-editor'
-import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@pico2map/tiled-map'
+import { Projects } from '@piyoppi/map-editor'
+import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@piyoppi/tiled-map'
 
 // Map size is 30 x 30, MapChip size is 32 x 32px
 const tiledMap = new TiledMap(30, 30, 32, 32)

--- a/packages/map-editor-examples/autotile/README.md
+++ b/packages/map-editor-examples/autotile/README.md
@@ -28,8 +28,8 @@ The AutoTile format is shown below.
 ```
 
 ```ts
-import { Projects } from '@piyoppi/map-editor'
-import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@piyoppi/tiled-map'
+import { Projects } from '@piyoppi/pico2map-editor'
+import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@piyoppi/pico2map-tiled'
 
 // Map size is 30 x 30, MapChip size is 32 x 32px
 const tiledMap = new TiledMap(30, 30, 32, 32)

--- a/packages/map-editor-examples/autotile/src/autotile.ts
+++ b/packages/map-editor-examples/autotile/src/autotile.ts
@@ -1,5 +1,5 @@
-import { Projects } from '@pico2map/map-editor'
-import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@pico2map/tiled-map'
+import { Projects } from '@piyoppi/map-editor'
+import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@piyoppi/tiled-map'
 
 // Map size is 30 x 30, MapChip size is 32 x 32px
 const tiledMap = new TiledMap(30, 30, 32, 32)

--- a/packages/map-editor-examples/autotile/src/autotile.ts
+++ b/packages/map-editor-examples/autotile/src/autotile.ts
@@ -1,5 +1,5 @@
-import { Projects } from '@piyoppi/map-editor'
-import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@piyoppi/tiled-map'
+import { Projects } from '@piyoppi/pico2map-editor'
+import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@piyoppi/pico2map-tiled'
 
 // Map size is 30 x 30, MapChip size is 32 x 32px
 const tiledMap = new TiledMap(30, 30, 32, 32)

--- a/packages/map-editor-examples/minimum_example/README.md
+++ b/packages/map-editor-examples/minimum_example/README.md
@@ -23,8 +23,8 @@ The `mapChipFragmentProperties` attribute must be set on the `<map-canvas-compon
 ```
 
 ```ts
-import { Projects } from '@piyoppi/map-editor'
-import { TiledMap, MapChipImage } from '@piyoppi/tiled-map'
+import { Projects } from '@piyoppi/pico2map-editor'
+import { TiledMap, MapChipImage } from '@piyoppi/pico2map-tiled'
 
 // Map size is 15 x 10, MapChip size is 32 x 32px
 const tiledMap = new TiledMap(15, 10, 32, 32)

--- a/packages/map-editor-examples/minimum_example/README.md
+++ b/packages/map-editor-examples/minimum_example/README.md
@@ -23,8 +23,8 @@ The `mapChipFragmentProperties` attribute must be set on the `<map-canvas-compon
 ```
 
 ```ts
-import { Projects } from '@pico2map/map-editor'
-import { TiledMap, MapChipImage } from '@pico2map/tiled-map'
+import { Projects } from '@piyoppi/map-editor'
+import { TiledMap, MapChipImage } from '@piyoppi/tiled-map'
 
 // Map size is 15 x 10, MapChip size is 32 x 32px
 const tiledMap = new TiledMap(15, 10, 32, 32)

--- a/packages/map-editor-examples/minimum_example/src/minimum_example.ts
+++ b/packages/map-editor-examples/minimum_example/src/minimum_example.ts
@@ -1,5 +1,5 @@
-import { Projects } from '@pico2map/map-editor'
-import { TiledMap, MapChipImage } from '@pico2map/tiled-map'
+import { Projects } from '@piyoppi/map-editor'
+import { TiledMap, MapChipImage } from '@piyoppi/tiled-map'
 
 // Map size is 15 x 10, MapChip size is 32 x 32px
 const tiledMap = new TiledMap(15, 10, 32, 32)

--- a/packages/map-editor-examples/minimum_example/src/minimum_example.ts
+++ b/packages/map-editor-examples/minimum_example/src/minimum_example.ts
@@ -1,5 +1,5 @@
-import { Projects } from '@piyoppi/map-editor'
-import { TiledMap, MapChipImage } from '@piyoppi/tiled-map'
+import { Projects } from '@piyoppi/pico2map-editor'
+import { TiledMap, MapChipImage } from '@piyoppi/pico2map-tiled'
 
 // Map size is 15 x 10, MapChip size is 32 x 32px
 const tiledMap = new TiledMap(15, 10, 32, 32)

--- a/packages/map-editor-examples/package.json
+++ b/packages/map-editor-examples/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "typescript": "^4.1.3",
-    "@pico2map/map-editor": "0.0.1",
-    "@pico2map/tiled-map": "0.0.1"
+    "@piyoppi/map-editor": "0.0.1",
+    "@piyoppi/tiled-map": "0.0.1"
   },
   "devDependencies": {
     "ts-loader": "^8.0.12",

--- a/packages/map-editor-examples/package.json
+++ b/packages/map-editor-examples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pico2map/map-editor-samples",
+  "name": "@piyoppi/pico2map-samples",
   "version": "0.0.1",
   "description": "",
   "main": "src/main.js",
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "typescript": "^4.1.3",
-    "@piyoppi/map-editor": "0.0.1",
-    "@piyoppi/tiled-map": "0.0.1"
+    "@piyoppi/pico2map-editor": "0.0.1",
+    "@piyoppi/pico2map-tiled": "0.0.1"
   },
   "devDependencies": {
     "ts-loader": "^8.0.12",

--- a/packages/map-editor-examples/simple_map_editor/README.md
+++ b/packages/map-editor-examples/simple_map_editor/README.md
@@ -47,8 +47,8 @@ The simple map editor consists of some components.
 ```
 
 ```js
-import { Projects, MapChipSelectedEvent, AutoTileSelectedEvent } from '@piyoppi/map-editor'
-import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@piyoppi/tiled-map'
+import { Projects, MapChipSelectedEvent, AutoTileSelectedEvent } from '@piyoppi/pico2map-editor'
+import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@piyoppi/pico2map-tiled'
 
 // Get some elements
 const mapCanvas = document.getElementById('mapCanvas') as HTMLInputElement

--- a/packages/map-editor-examples/simple_map_editor/README.md
+++ b/packages/map-editor-examples/simple_map_editor/README.md
@@ -47,8 +47,8 @@ The simple map editor consists of some components.
 ```
 
 ```js
-import { Projects, MapChipSelectedEvent, AutoTileSelectedEvent } from '@pico2map/map-editor'
-import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@pico2map/tiled-map'
+import { Projects, MapChipSelectedEvent, AutoTileSelectedEvent } from '@piyoppi/map-editor'
+import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@piyoppi/tiled-map'
 
 // Get some elements
 const mapCanvas = document.getElementById('mapCanvas') as HTMLInputElement

--- a/packages/map-editor-examples/simple_map_editor/src/simple_map_editor.ts
+++ b/packages/map-editor-examples/simple_map_editor/src/simple_map_editor.ts
@@ -1,5 +1,5 @@
-import { Projects, MapChipSelectedEvent, AutoTileSelectedEvent } from '@piyoppi/map-editor'
-import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@piyoppi/tiled-map'
+import { Projects, MapChipSelectedEvent, AutoTileSelectedEvent } from '@piyoppi/pico2map-editor'
+import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@piyoppi/pico2map-tiled'
 
 // Get some elements
 const mapCanvas = document.getElementById('mapCanvas') as HTMLInputElement

--- a/packages/map-editor-examples/simple_map_editor/src/simple_map_editor.ts
+++ b/packages/map-editor-examples/simple_map_editor/src/simple_map_editor.ts
@@ -1,5 +1,5 @@
-import { Projects, MapChipSelectedEvent, AutoTileSelectedEvent } from '@pico2map/map-editor'
-import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@pico2map/tiled-map'
+import { Projects, MapChipSelectedEvent, AutoTileSelectedEvent } from '@piyoppi/map-editor'
+import { TiledMap, MapChipImage, DefaultAutoTileImportStrategy } from '@piyoppi/tiled-map'
 
 // Get some elements
 const mapCanvas = document.getElementById('mapCanvas') as HTMLInputElement

--- a/packages/map-editor/package.json
+++ b/packages/map-editor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pico2map/map-editor",
+  "name": "@piyoppi/pico2map-editor",
   "version": "0.0.1",
   "description": "",
   "main": "dist/main.js",
@@ -18,7 +18,7 @@
     "ts-loader": "^8.0.14",
     "webpack": "^5.17.0",
     "webpack-cli": "^4.4.0",
-    "@piyoppi/tiled-map": "0.0.1"
+    "@piyoppi/pico2map-tiled": "0.0.1"
   },
   "scripts": {
     "test": "jest",

--- a/packages/map-editor/package.json
+++ b/packages/map-editor/package.json
@@ -18,7 +18,7 @@
     "ts-loader": "^8.0.14",
     "webpack": "^5.17.0",
     "webpack-cli": "^4.4.0",
-    "@pico2map/tiled-map": "0.0.1"
+    "@piyoppi/tiled-map": "0.0.1"
   },
   "scripts": {
     "test": "jest",

--- a/packages/map-editor/src/AutoTileSelector.ts
+++ b/packages/map-editor/src/AutoTileSelector.ts
@@ -1,4 +1,4 @@
-import { AutoTile, AutoTiles, MapChipsCollection } from '@piyoppi/tiled-map'
+import { AutoTile, AutoTiles, MapChipsCollection } from '@piyoppi/pico2map-tiled'
 
 export class AutoTileSelector {
   private _indexImageWidth = 0

--- a/packages/map-editor/src/AutoTileSelector.ts
+++ b/packages/map-editor/src/AutoTileSelector.ts
@@ -1,4 +1,4 @@
-import { AutoTile, AutoTiles, MapChipsCollection } from '@pico2map/tiled-map'
+import { AutoTile, AutoTiles, MapChipsCollection } from '@piyoppi/tiled-map'
 
 export class AutoTileSelector {
   private _indexImageWidth = 0

--- a/packages/map-editor/src/Brushes/Arrangements/Arrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/Arrangement.ts
@@ -1,4 +1,4 @@
-import { MapChipFragment, TiledMapData, AutoTile, AutoTiles, ColiderTypes } from '@pico2map/tiled-map'
+import { MapChipFragment, TiledMapData, AutoTile, AutoTiles, ColiderTypes } from '@piyoppi/tiled-map'
 import { BrushPaint } from './../Brush'
 
 export interface ArrangementPaint<T> {

--- a/packages/map-editor/src/Brushes/Arrangements/Arrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/Arrangement.ts
@@ -1,4 +1,4 @@
-import { MapChipFragment, TiledMapData, AutoTile, AutoTiles, ColiderTypes } from '@piyoppi/tiled-map'
+import { MapChipFragment, TiledMapData, AutoTile, AutoTiles, ColiderTypes } from '@piyoppi/pico2map-tiled'
 import { BrushPaint } from './../Brush'
 
 export interface ArrangementPaint<T> {

--- a/packages/map-editor/src/Brushes/Arrangements/AutoTileArrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/AutoTileArrangement.ts
@@ -1,6 +1,6 @@
 import { Arrangement, ArrangementPaint, ArrangementDescription, TiledMapDataRequired, AutoTileRequired, MapChipFragmentRequired } from './Arrangement';
 import { BrushPaint } from './../Brush'
-import { MapChipFragment, AutoTileMapChip, isAutoTileMapChip, TiledMapData, TiledMapDataItem, AutoTile } from '@pico2map/tiled-map'
+import { MapChipFragment, AutoTileMapChip, isAutoTileMapChip, TiledMapData, TiledMapDataItem, AutoTile } from '@piyoppi/tiled-map'
 
 export const AutoTileArrangementDescription: ArrangementDescription<TiledMapDataItem> = {
   name: 'AutoTileArrangement',

--- a/packages/map-editor/src/Brushes/Arrangements/AutoTileArrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/AutoTileArrangement.ts
@@ -1,6 +1,6 @@
 import { Arrangement, ArrangementPaint, ArrangementDescription, TiledMapDataRequired, AutoTileRequired, MapChipFragmentRequired } from './Arrangement';
 import { BrushPaint } from './../Brush'
-import { MapChipFragment, AutoTileMapChip, isAutoTileMapChip, TiledMapData, TiledMapDataItem, AutoTile } from '@piyoppi/tiled-map'
+import { MapChipFragment, AutoTileMapChip, isAutoTileMapChip, TiledMapData, TiledMapDataItem, AutoTile } from '@piyoppi/pico2map-tiled'
 
 export const AutoTileArrangementDescription: ArrangementDescription<TiledMapDataItem> = {
   name: 'AutoTileArrangement',

--- a/packages/map-editor/src/Brushes/Arrangements/AutoTileEraseArrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/AutoTileEraseArrangement.ts
@@ -1,7 +1,7 @@
 import { Arrangement, ArrangementPaint, ArrangementDescription, TiledMapDataRequired, AutoTilesRequired } from './Arrangement'
 import { BrushPaint } from './../Brush'
 import { AutoTileArrangement } from './AutoTileArrangement'
-import { MapChipFragment, TiledMapData, TiledMapDataItem, AutoTileMapChip, AutoTiles, isAutoTileMapChip } from '@pico2map/tiled-map'
+import { MapChipFragment, TiledMapData, TiledMapDataItem, AutoTileMapChip, AutoTiles, isAutoTileMapChip } from '@piyoppi/tiled-map'
 
 export const AutoTileEraseArrangementDescription: ArrangementDescription<TiledMapDataItem> = {
   name: 'AutoTileEraseArrangement',

--- a/packages/map-editor/src/Brushes/Arrangements/AutoTileEraseArrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/AutoTileEraseArrangement.ts
@@ -1,7 +1,7 @@
 import { Arrangement, ArrangementPaint, ArrangementDescription, TiledMapDataRequired, AutoTilesRequired } from './Arrangement'
 import { BrushPaint } from './../Brush'
 import { AutoTileArrangement } from './AutoTileArrangement'
-import { MapChipFragment, TiledMapData, TiledMapDataItem, AutoTileMapChip, AutoTiles, isAutoTileMapChip } from '@piyoppi/tiled-map'
+import { MapChipFragment, TiledMapData, TiledMapDataItem, AutoTileMapChip, AutoTiles, isAutoTileMapChip } from '@piyoppi/pico2map-tiled'
 
 export const AutoTileEraseArrangementDescription: ArrangementDescription<TiledMapDataItem> = {
   name: 'AutoTileEraseArrangement',

--- a/packages/map-editor/src/Brushes/Arrangements/ColiderArrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/ColiderArrangement.ts
@@ -1,4 +1,4 @@
-import { ColiderTypes } from '@piyoppi/tiled-map'
+import { ColiderTypes } from '@piyoppi/pico2map-tiled'
 import { Arrangement, ArrangementPaint, ArrangementDescription, ColiderTypesRequired } from './Arrangement'
 import { BrushPaint } from './../Brush'
 

--- a/packages/map-editor/src/Brushes/Arrangements/ColiderArrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/ColiderArrangement.ts
@@ -1,4 +1,4 @@
-import { ColiderTypes } from '@pico2map/tiled-map'
+import { ColiderTypes } from '@piyoppi/tiled-map'
 import { Arrangement, ArrangementPaint, ArrangementDescription, ColiderTypesRequired } from './Arrangement'
 import { BrushPaint } from './../Brush'
 

--- a/packages/map-editor/src/Brushes/Arrangements/DefaultArrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/DefaultArrangement.ts
@@ -1,4 +1,4 @@
-import { MapChipFragment, MapChip, TiledMapDataItem } from '@piyoppi/tiled-map'
+import { MapChipFragment, MapChip, TiledMapDataItem } from '@piyoppi/pico2map-tiled'
 import { Arrangement, ArrangementPaint, ArrangementDescription, MapChipFragmentRequired } from './Arrangement'
 import { BrushPaint } from './../Brush'
 

--- a/packages/map-editor/src/Brushes/Arrangements/DefaultArrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/DefaultArrangement.ts
@@ -1,4 +1,4 @@
-import { MapChipFragment, MapChip, TiledMapDataItem } from '@pico2map/tiled-map'
+import { MapChipFragment, MapChip, TiledMapDataItem } from '@piyoppi/tiled-map'
 import { Arrangement, ArrangementPaint, ArrangementDescription, MapChipFragmentRequired } from './Arrangement'
 import { BrushPaint } from './../Brush'
 

--- a/packages/map-editor/src/Brushes/Arrangements/DefaultEraseArrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/DefaultEraseArrangement.ts
@@ -2,7 +2,7 @@ import { Arrangement, ArrangementPaint, ArrangementDescription, TiledMapDataRequ
 import { EraseArrangement } from './EraseArrangement'
 import { AutoTileEraseArrangement } from './AutoTileEraseArrangement'
 import { BrushPaint } from './../Brush'
-import { MapChipFragment, TiledMapData, TiledMapDataItem, AutoTiles } from '@pico2map/tiled-map'
+import { MapChipFragment, TiledMapData, TiledMapDataItem, AutoTiles } from '@piyoppi/tiled-map'
 
 export const DefaultEraseArrangementDescription: ArrangementDescription<TiledMapDataItem> = {
   name: 'DefaultEraseArrangement',

--- a/packages/map-editor/src/Brushes/Arrangements/DefaultEraseArrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/DefaultEraseArrangement.ts
@@ -2,7 +2,7 @@ import { Arrangement, ArrangementPaint, ArrangementDescription, TiledMapDataRequ
 import { EraseArrangement } from './EraseArrangement'
 import { AutoTileEraseArrangement } from './AutoTileEraseArrangement'
 import { BrushPaint } from './../Brush'
-import { MapChipFragment, TiledMapData, TiledMapDataItem, AutoTiles } from '@piyoppi/tiled-map'
+import { MapChipFragment, TiledMapData, TiledMapDataItem, AutoTiles } from '@piyoppi/pico2map-tiled'
 
 export const DefaultEraseArrangementDescription: ArrangementDescription<TiledMapDataItem> = {
   name: 'DefaultEraseArrangement',

--- a/packages/map-editor/src/Brushes/Arrangements/EraseArrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/EraseArrangement.ts
@@ -1,4 +1,4 @@
-import { MapChipFragment, MapChip, TiledMapDataItem } from '@pico2map/tiled-map'
+import { MapChipFragment, MapChip, TiledMapDataItem } from '@piyoppi/tiled-map'
 import { Arrangement, ArrangementPaint, ArrangementDescription } from './Arrangement'
 import { BrushPaint } from './../Brush'
 

--- a/packages/map-editor/src/Brushes/Arrangements/EraseArrangement.ts
+++ b/packages/map-editor/src/Brushes/Arrangements/EraseArrangement.ts
@@ -1,4 +1,4 @@
-import { MapChipFragment, MapChip, TiledMapDataItem } from '@piyoppi/tiled-map'
+import { MapChipFragment, MapChip, TiledMapDataItem } from '@piyoppi/pico2map-tiled'
 import { Arrangement, ArrangementPaint, ArrangementDescription } from './Arrangement'
 import { BrushPaint } from './../Brush'
 

--- a/packages/map-editor/src/Brushes/Brush.ts
+++ b/packages/map-editor/src/Brushes/Brush.ts
@@ -1,5 +1,5 @@
 import { Arrangement, ArrangementPaint } from './Arrangements/Arrangement';
-import { MapChip } from '@pico2map/tiled-map'
+import { MapChip } from '@piyoppi/tiled-map'
 
 export interface BrushPaint {
   x: number,

--- a/packages/map-editor/src/Brushes/Brush.ts
+++ b/packages/map-editor/src/Brushes/Brush.ts
@@ -1,5 +1,5 @@
 import { Arrangement, ArrangementPaint } from './Arrangements/Arrangement';
-import { MapChip } from '@piyoppi/tiled-map'
+import { MapChip } from '@piyoppi/pico2map-tiled'
 
 export interface BrushPaint {
   x: number,

--- a/packages/map-editor/src/Brushes/Pen.ts
+++ b/packages/map-editor/src/Brushes/Pen.ts
@@ -1,7 +1,7 @@
 import { Brush, BrushPaint, BrushDescription } from './Brush'
 import { Arrangement, ArrangementPaint } from './Arrangements/Arrangement'
 import { DefaultArrangement } from './Arrangements/DefaultArrangement'
-import { TiledMapDataItem } from '@pico2map/tiled-map'
+import { TiledMapDataItem } from '@piyoppi/tiled-map'
 
 export const PenDescription: BrushDescription = {
   name: 'Pen',

--- a/packages/map-editor/src/Brushes/Pen.ts
+++ b/packages/map-editor/src/Brushes/Pen.ts
@@ -1,7 +1,7 @@
 import { Brush, BrushPaint, BrushDescription } from './Brush'
 import { Arrangement, ArrangementPaint } from './Arrangements/Arrangement'
 import { DefaultArrangement } from './Arrangements/DefaultArrangement'
-import { TiledMapDataItem } from '@piyoppi/tiled-map'
+import { TiledMapDataItem } from '@piyoppi/pico2map-tiled'
 
 export const PenDescription: BrushDescription = {
   name: 'Pen',

--- a/packages/map-editor/src/Brushes/RectangleBrush.ts
+++ b/packages/map-editor/src/Brushes/RectangleBrush.ts
@@ -1,7 +1,7 @@
 import { Brush, BrushPaint, BrushDescription } from './Brush'
 import { Arrangement, ArrangementPaint } from './Arrangements/Arrangement'
 import { DefaultArrangement } from './Arrangements/DefaultArrangement'
-import { TiledMapDataItem } from '@piyoppi/tiled-map'
+import { TiledMapDataItem } from '@piyoppi/pico2map-tiled'
 
 export const RectangleBrushDescription: BrushDescription = {
   name: 'RectangleBrush',

--- a/packages/map-editor/src/Brushes/RectangleBrush.ts
+++ b/packages/map-editor/src/Brushes/RectangleBrush.ts
@@ -1,7 +1,7 @@
 import { Brush, BrushPaint, BrushDescription } from './Brush'
 import { Arrangement, ArrangementPaint } from './Arrangements/Arrangement'
 import { DefaultArrangement } from './Arrangements/DefaultArrangement'
-import { TiledMapDataItem } from '@pico2map/tiled-map'
+import { TiledMapDataItem } from '@piyoppi/tiled-map'
 
 export const RectangleBrushDescription: BrushDescription = {
   name: 'RectangleBrush',

--- a/packages/map-editor/src/ColiderCanvas.ts
+++ b/packages/map-editor/src/ColiderCanvas.ts
@@ -1,6 +1,6 @@
 import { Project } from './Projects'
 import { ColiderRenderer } from './ColiderRenderer'
-import { ColiderTypes } from '@piyoppi/tiled-map'
+import { ColiderTypes } from '@piyoppi/pico2map-tiled'
 import { Pen } from './Brushes/Pen'
 import { Brush } from './Brushes/Brush'
 import { Arrangement, isColiderTypesRequired } from './Brushes/Arrangements/Arrangement'

--- a/packages/map-editor/src/ColiderCanvas.ts
+++ b/packages/map-editor/src/ColiderCanvas.ts
@@ -1,6 +1,6 @@
 import { Project } from './Projects'
 import { ColiderRenderer } from './ColiderRenderer'
-import { ColiderTypes } from '@pico2map/tiled-map'
+import { ColiderTypes } from '@piyoppi/tiled-map'
 import { Pen } from './Brushes/Pen'
 import { Brush } from './Brushes/Brush'
 import { Arrangement, isColiderTypesRequired } from './Brushes/Arrangements/Arrangement'

--- a/packages/map-editor/src/ColiderRenderer.ts
+++ b/packages/map-editor/src/ColiderRenderer.ts
@@ -1,4 +1,4 @@
-import { TiledMap, MapChipFragment, MapChip, ColiderTypes } from '@piyoppi/tiled-map'
+import { TiledMap, MapChipFragment, MapChip, ColiderTypes } from '@piyoppi/pico2map-tiled'
 
 export class ColiderRenderer {
   private _backgroundRgba = {r: 255, g: 255, b: 255, a: 1.0}

--- a/packages/map-editor/src/ColiderRenderer.ts
+++ b/packages/map-editor/src/ColiderRenderer.ts
@@ -1,4 +1,4 @@
-import { TiledMap, MapChipFragment, MapChip, ColiderTypes } from '@pico2map/tiled-map'
+import { TiledMap, MapChipFragment, MapChip, ColiderTypes } from '@piyoppi/tiled-map'
 
 export class ColiderRenderer {
   private _backgroundRgba = {r: 255, g: 255, b: 255, a: 1.0}

--- a/packages/map-editor/src/Components/MapCanvasComponent.ts
+++ b/packages/map-editor/src/Components/MapCanvasComponent.ts
@@ -5,7 +5,7 @@ import { MapCanvas } from './../MapCanvas'
 import { Projects, Project } from './../Projects'
 import { ColiderCanvas } from '../ColiderCanvas'
 import { EditorCanvas } from '../EditorCanvas'
-import { TiledMap, MapChipFragment, MapChipFragmentProperties, ColiderTypes } from '@piyoppi/tiled-map'
+import { TiledMap, MapChipFragment, MapChipFragmentProperties, ColiderTypes } from '@piyoppi/pico2map-tiled'
 
 type EditMode = 'mapChip' | 'colider'
 

--- a/packages/map-editor/src/Components/MapCanvasComponent.ts
+++ b/packages/map-editor/src/Components/MapCanvasComponent.ts
@@ -5,7 +5,7 @@ import { MapCanvas } from './../MapCanvas'
 import { Projects, Project } from './../Projects'
 import { ColiderCanvas } from '../ColiderCanvas'
 import { EditorCanvas } from '../EditorCanvas'
-import { TiledMap, MapChipFragment, MapChipFragmentProperties, ColiderTypes } from '@pico2map/tiled-map'
+import { TiledMap, MapChipFragment, MapChipFragmentProperties, ColiderTypes } from '@piyoppi/tiled-map'
 
 type EditMode = 'mapChip' | 'colider'
 

--- a/packages/map-editor/src/Components/MapChipSelectorComponent.ts
+++ b/packages/map-editor/src/Components/MapChipSelectorComponent.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css, customElement, property } from 'lit-element'
 import { GridImageGenerator } from '../GridImageGenerator'
 import { CursorPositionCalculator } from './helpers/CursorPositionCalculator'
 import { Projects, Project } from './../Projects'
-import { MapChipImage, MapChipFragmentProperties } from '@pico2map/tiled-map'
+import { MapChipImage, MapChipFragmentProperties } from '@piyoppi/tiled-map'
 import { MapChipSelector } from '../MapChipSelector'
 
 interface MapChipSelectedDetail {

--- a/packages/map-editor/src/Components/MapChipSelectorComponent.ts
+++ b/packages/map-editor/src/Components/MapChipSelectorComponent.ts
@@ -2,7 +2,7 @@ import { LitElement, html, css, customElement, property } from 'lit-element'
 import { GridImageGenerator } from '../GridImageGenerator'
 import { CursorPositionCalculator } from './helpers/CursorPositionCalculator'
 import { Projects, Project } from './../Projects'
-import { MapChipImage, MapChipFragmentProperties } from '@piyoppi/tiled-map'
+import { MapChipImage, MapChipFragmentProperties } from '@piyoppi/pico2map-tiled'
 import { MapChipSelector } from '../MapChipSelector'
 
 interface MapChipSelectedDetail {

--- a/packages/map-editor/src/MapCanvas.ts
+++ b/packages/map-editor/src/MapCanvas.ts
@@ -1,4 +1,4 @@
-import { TiledMapDataItem, MapChipFragment, MapChip, AutoTile } from '@piyoppi/tiled-map'
+import { TiledMapDataItem, MapChipFragment, MapChip, AutoTile } from '@piyoppi/pico2map-tiled'
 import { Project } from './Projects'
 import { Pen } from './Brushes/Pen'
 import { Brushes } from './Brushes/Brushes'

--- a/packages/map-editor/src/MapCanvas.ts
+++ b/packages/map-editor/src/MapCanvas.ts
@@ -1,4 +1,4 @@
-import { TiledMapDataItem, MapChipFragment, MapChip, AutoTile } from '@pico2map/tiled-map'
+import { TiledMapDataItem, MapChipFragment, MapChip, AutoTile } from '@piyoppi/tiled-map'
 import { Project } from './Projects'
 import { Pen } from './Brushes/Pen'
 import { Brushes } from './Brushes/Brushes'

--- a/packages/map-editor/src/MapChipSelector.ts
+++ b/packages/map-editor/src/MapChipSelector.ts
@@ -1,4 +1,4 @@
-import { TiledMap, MapChipFragment, MapChipImage } from '@piyoppi/tiled-map'
+import { TiledMap, MapChipFragment, MapChipImage } from '@piyoppi/pico2map-tiled'
 
 export class MapChipSelector {
   private _selectedChips: Array<MapChipFragment> = []

--- a/packages/map-editor/src/MapChipSelector.ts
+++ b/packages/map-editor/src/MapChipSelector.ts
@@ -1,4 +1,4 @@
-import { TiledMap, MapChipFragment, MapChipImage } from '@pico2map/tiled-map'
+import { TiledMap, MapChipFragment, MapChipImage } from '@piyoppi/tiled-map'
 
 export class MapChipSelector {
   private _selectedChips: Array<MapChipFragment> = []

--- a/packages/map-editor/src/MapRenderer.ts
+++ b/packages/map-editor/src/MapRenderer.ts
@@ -1,4 +1,4 @@
-import { TiledMap, MapChipFragment, MapChip } from '@pico2map/tiled-map'
+import { TiledMap, MapChipFragment, MapChip } from '@piyoppi/tiled-map'
 
 export class MapRenderer {
   private _backgroundRgba = {r: 255, g: 255, b: 255, a: 1.0}

--- a/packages/map-editor/src/MapRenderer.ts
+++ b/packages/map-editor/src/MapRenderer.ts
@@ -1,4 +1,4 @@
-import { TiledMap, MapChipFragment, MapChip } from '@piyoppi/tiled-map'
+import { TiledMap, MapChipFragment, MapChip } from '@piyoppi/pico2map-tiled'
 
 export class MapRenderer {
   private _backgroundRgba = {r: 255, g: 255, b: 255, a: 1.0}

--- a/packages/map-editor/src/Projects.ts
+++ b/packages/map-editor/src/Projects.ts
@@ -1,4 +1,4 @@
-import { TiledMap } from '@pico2map/tiled-map'
+import { TiledMap } from '@piyoppi/tiled-map'
 
 export class Project {
   private _renderAllFunction: Array<(() => void)> = []

--- a/packages/map-editor/src/Projects.ts
+++ b/packages/map-editor/src/Projects.ts
@@ -1,4 +1,4 @@
-import { TiledMap } from '@piyoppi/tiled-map'
+import { TiledMap } from '@piyoppi/pico2map-tiled'
 
 export class Project {
   private _renderAllFunction: Array<(() => void)> = []

--- a/packages/map-editor/tests/Brushes/Arrangements/AutoTileArrangement.test.ts
+++ b/packages/map-editor/tests/Brushes/Arrangements/AutoTileArrangement.test.ts
@@ -1,5 +1,5 @@
 import { AutoTileArrangement } from './../../../src/Brushes/Arrangements/AutoTileArrangement'
-import { AutoTile, TiledMapData, MapChip, MapChipFragment, AutoTileMapChip } from '@pico2map/tiled-map'
+import { AutoTile, TiledMapData, MapChip, MapChipFragment, AutoTileMapChip } from '@piyoppi/tiled-map'
 
 const tiledMapData = new TiledMapData(3, 3)
 const chipId = 2

--- a/packages/map-editor/tests/Brushes/Arrangements/AutoTileArrangement.test.ts
+++ b/packages/map-editor/tests/Brushes/Arrangements/AutoTileArrangement.test.ts
@@ -1,5 +1,5 @@
 import { AutoTileArrangement } from './../../../src/Brushes/Arrangements/AutoTileArrangement'
-import { AutoTile, TiledMapData, MapChip, MapChipFragment, AutoTileMapChip } from '@piyoppi/tiled-map'
+import { AutoTile, TiledMapData, MapChip, MapChipFragment, AutoTileMapChip } from '@piyoppi/pico2map-tiled'
 
 const tiledMapData = new TiledMapData(3, 3)
 const chipId = 2

--- a/packages/map-editor/tests/Brushes/Pen.test.ts
+++ b/packages/map-editor/tests/Brushes/Pen.test.ts
@@ -1,4 +1,4 @@
-import { MapChip, MapChipFragment, TiledMapDataItem } from '@pico2map/tiled-map';
+import { MapChip, MapChipFragment, TiledMapDataItem } from '@piyoppi/tiled-map';
 import { Pen } from './../../src/Brushes/Pen'
 import { DefaultArrangement } from './../../src/Brushes/Arrangements/DefaultArrangement'
 

--- a/packages/map-editor/tests/Brushes/Pen.test.ts
+++ b/packages/map-editor/tests/Brushes/Pen.test.ts
@@ -1,4 +1,4 @@
-import { MapChip, MapChipFragment, TiledMapDataItem } from '@piyoppi/tiled-map';
+import { MapChip, MapChipFragment, TiledMapDataItem } from '@piyoppi/pico2map-tiled';
 import { Pen } from './../../src/Brushes/Pen'
 import { DefaultArrangement } from './../../src/Brushes/Arrangements/DefaultArrangement'
 

--- a/packages/map-editor/tests/Brushes/RectangleBrush.test.ts
+++ b/packages/map-editor/tests/Brushes/RectangleBrush.test.ts
@@ -1,4 +1,4 @@
-import { MapChip, MapChipFragment, TiledMapDataItem } from '@piyoppi/tiled-map';
+import { MapChip, MapChipFragment, TiledMapDataItem } from '@piyoppi/pico2map-tiled';
 import { RectangleBrush } from './../../src/Brushes/RectangleBrush'
 import { DefaultArrangement } from './../../src/Brushes/Arrangements/DefaultArrangement'
 

--- a/packages/map-editor/tests/Brushes/RectangleBrush.test.ts
+++ b/packages/map-editor/tests/Brushes/RectangleBrush.test.ts
@@ -1,4 +1,4 @@
-import { MapChip, MapChipFragment, TiledMapDataItem } from '@pico2map/tiled-map';
+import { MapChip, MapChipFragment, TiledMapDataItem } from '@piyoppi/tiled-map';
 import { RectangleBrush } from './../../src/Brushes/RectangleBrush'
 import { DefaultArrangement } from './../../src/Brushes/Arrangements/DefaultArrangement'
 

--- a/packages/map-editor/tests/Projects.test.ts
+++ b/packages/map-editor/tests/Projects.test.ts
@@ -1,5 +1,5 @@
 import { Projects } from './../src/Projects'
-import { TiledMap } from '@pico2map/tiled-map'
+import { TiledMap } from '@piyoppi/tiled-map'
 
 describe('#add', () => {
   it('Should add a project', () => {

--- a/packages/map-editor/tests/Projects.test.ts
+++ b/packages/map-editor/tests/Projects.test.ts
@@ -1,5 +1,5 @@
 import { Projects } from './../src/Projects'
-import { TiledMap } from '@piyoppi/tiled-map'
+import { TiledMap } from '@piyoppi/pico2map-tiled'
 
 describe('#add', () => {
   it('Should add a project', () => {

--- a/packages/tiled-map/package.json
+++ b/packages/tiled-map/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pico2map/tiled-map",
+  "name": "@piyoppi/pico2map-tiled",
   "version": "0.0.1",
   "description": "",
   "main": "dist/main.js",


### PR DESCRIPTION
- 当初は `@pico2map` というスコープを付けてGitHub Packagesで公開するつもりだった
- ただし、GitHub Packagesで公開する場合、スコープと所有者（Owner / Organization）の名称が一致している必要がありそう
  - https://docs.github.com/en/packages/guides/configuring-npm-for-use-with-github-packages
- Organizationをつくってもいいけれど、まだ広く公開できる出来でもないし、とりあえずは `@piyoppi` で開発しておいて、メジャーバージョンを更新するときに再度検討することにした
  - なので、pico2map Organization はつくってしまった
- スコープが `@piyoppi` になるので、pico2map 関連パッケージであることが分かるようにパッケージ名をリネーム