### PR TITLE
pico2map-ui-componentsのビルド成果物が正しくパッケージに反映されるようにする

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,11 @@ jobs:
           name: built-map-editor
           path: ./packages/map-editor/dist/
 
+      - uses: actions/download-artifact@v2
+        with:
+          name: built-ui-components
+          path: ./packages/map-editor-components/dist/
+
       - run: npm publish
         working-directory: ./packages/tiled-map
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7229,13 +7229,13 @@
     },
     "packages/map-editor": {
       "name": "@piyoppi/pico2map-editor",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "MIT",
       "dependencies": {
         "typescript": "^4.1.3"
       },
       "devDependencies": {
-        "@piyoppi/pico2map-tiled": "0.0.17",
+        "@piyoppi/pico2map-tiled": "0.0.18",
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3",
         "ts-jest": "^26.4.4",
@@ -7246,15 +7246,15 @@
     },
     "packages/map-editor-components": {
       "name": "@piyoppi/pico2map-ui-components",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "MIT",
       "dependencies": {
         "lit-element": "^2.4.0",
         "typescript": "^4.1.3"
       },
       "devDependencies": {
-        "@piyoppi/pico2map-editor": "0.0.17",
-        "@piyoppi/pico2map-tiled": "0.0.17",
+        "@piyoppi/pico2map-editor": "0.0.18",
+        "@piyoppi/pico2map-tiled": "0.0.18",
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3",
         "ts-jest": "^26.4.4",
@@ -7265,11 +7265,11 @@
     },
     "packages/map-editor-examples": {
       "name": "@piyoppi/pico2map-samples",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "MIT",
       "dependencies": {
-        "@piyoppi/pico2map-tiled": "0.0.17",
-        "@piyoppi/pico2map-ui-components": "0.0.17",
+        "@piyoppi/pico2map-tiled": "0.0.18",
+        "@piyoppi/pico2map-ui-components": "0.0.18",
         "typescript": "^4.1.3"
       },
       "devDependencies": {
@@ -7280,7 +7280,7 @@
     },
     "packages/tiled-map": {
       "name": "@piyoppi/pico2map-tiled",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "MIT",
       "dependencies": {
         "typescript": "^4.1.3"
@@ -7955,7 +7955,7 @@
     "@piyoppi/pico2map-editor": {
       "version": "file:packages/map-editor",
       "requires": {
-        "@piyoppi/pico2map-tiled": "0.0.17",
+        "@piyoppi/pico2map-tiled": "0.0.18",
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3",
         "ts-jest": "^26.4.4",
@@ -7968,8 +7968,8 @@
     "@piyoppi/pico2map-samples": {
       "version": "file:packages/map-editor-examples",
       "requires": {
-        "@piyoppi/pico2map-tiled": "0.0.17",
-        "@piyoppi/pico2map-ui-components": "0.0.17",
+        "@piyoppi/pico2map-tiled": "0.0.18",
+        "@piyoppi/pico2map-ui-components": "0.0.18",
         "ts-loader": "^8.0.12",
         "typescript": "^4.1.3",
         "webpack": "^5.10.3",
@@ -7991,8 +7991,8 @@
     "@piyoppi/pico2map-ui-components": {
       "version": "file:packages/map-editor-components",
       "requires": {
-        "@piyoppi/pico2map-editor": "0.0.17",
-        "@piyoppi/pico2map-tiled": "0.0.17",
+        "@piyoppi/pico2map-editor": "0.0.18",
+        "@piyoppi/pico2map-tiled": "0.0.18",
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3",
         "lit-element": "^2.4.0",

--- a/packages/map-editor-components/package.json
+++ b/packages/map-editor-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piyoppi/pico2map-ui-components",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "pico2map Web Components",
   "main": "dist/main.js",
   "repository": {
@@ -18,8 +18,8 @@
     "ts-loader": "^8.0.14",
     "webpack": "^5.17.0",
     "webpack-cli": "^4.4.0",
-    "@piyoppi/pico2map-tiled": "0.0.17",
-    "@piyoppi/pico2map-editor": "0.0.17"
+    "@piyoppi/pico2map-tiled": "0.0.18",
+    "@piyoppi/pico2map-editor": "0.0.18"
   },
   "scripts": {
     "test": "jest",

--- a/packages/map-editor-examples/package.json
+++ b/packages/map-editor-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piyoppi/pico2map-samples",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "",
   "main": "src/main.js",
   "directories": {
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "typescript": "^4.1.3",
-    "@piyoppi/pico2map-ui-components": "0.0.17",
-    "@piyoppi/pico2map-tiled": "0.0.17"
+    "@piyoppi/pico2map-ui-components": "0.0.18",
+    "@piyoppi/pico2map-tiled": "0.0.18"
   },
   "devDependencies": {
     "ts-loader": "^8.0.12",

--- a/packages/map-editor/package.json
+++ b/packages/map-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piyoppi/pico2map-editor",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "",
   "main": "dist/main.js",
   "repository": {
@@ -17,7 +17,7 @@
     "ts-loader": "^8.0.14",
     "webpack": "^5.17.0",
     "webpack-cli": "^4.4.0",
-    "@piyoppi/pico2map-tiled": "0.0.17"
+    "@piyoppi/pico2map-tiled": "0.0.18"
   },
   "scripts": {
     "test": "jest",

--- a/packages/tiled-map/package.json
+++ b/packages/tiled-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piyoppi/pico2map-tiled",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "",
   "main": "dist/main.js",
   "repository": {


### PR DESCRIPTION
パッケージを公開するワークフローにミスがあり、ビルドした成果物がバンドルされていなかったので修正します