### PR TITLE
要素の幅と高さを得るためにコンポーネントのスタイルを調整します

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7229,13 +7229,13 @@
     },
     "packages/map-editor": {
       "name": "@piyoppi/pico2map-editor",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "MIT",
       "dependencies": {
         "typescript": "^4.1.3"
       },
       "devDependencies": {
-        "@piyoppi/pico2map-tiled": "0.0.18",
+        "@piyoppi/pico2map-tiled": "0.0.19",
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3",
         "ts-jest": "^26.4.4",
@@ -7246,15 +7246,15 @@
     },
     "packages/map-editor-components": {
       "name": "@piyoppi/pico2map-ui-components",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "MIT",
       "dependencies": {
         "lit-element": "^2.4.0",
         "typescript": "^4.1.3"
       },
       "devDependencies": {
-        "@piyoppi/pico2map-editor": "0.0.18",
-        "@piyoppi/pico2map-tiled": "0.0.18",
+        "@piyoppi/pico2map-editor": "0.0.19",
+        "@piyoppi/pico2map-tiled": "0.0.19",
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3",
         "ts-jest": "^26.4.4",
@@ -7265,11 +7265,11 @@
     },
     "packages/map-editor-examples": {
       "name": "@piyoppi/pico2map-samples",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "MIT",
       "dependencies": {
-        "@piyoppi/pico2map-tiled": "0.0.18",
-        "@piyoppi/pico2map-ui-components": "0.0.18",
+        "@piyoppi/pico2map-tiled": "0.0.19",
+        "@piyoppi/pico2map-ui-components": "0.0.19",
         "typescript": "^4.1.3"
       },
       "devDependencies": {
@@ -7280,7 +7280,7 @@
     },
     "packages/tiled-map": {
       "name": "@piyoppi/pico2map-tiled",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "MIT",
       "dependencies": {
         "typescript": "^4.1.3"
@@ -7955,7 +7955,7 @@
     "@piyoppi/pico2map-editor": {
       "version": "file:packages/map-editor",
       "requires": {
-        "@piyoppi/pico2map-tiled": "0.0.18",
+        "@piyoppi/pico2map-tiled": "0.0.19",
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3",
         "ts-jest": "^26.4.4",
@@ -7968,8 +7968,8 @@
     "@piyoppi/pico2map-samples": {
       "version": "file:packages/map-editor-examples",
       "requires": {
-        "@piyoppi/pico2map-tiled": "0.0.18",
-        "@piyoppi/pico2map-ui-components": "0.0.18",
+        "@piyoppi/pico2map-tiled": "0.0.19",
+        "@piyoppi/pico2map-ui-components": "0.0.19",
         "ts-loader": "^8.0.12",
         "typescript": "^4.1.3",
         "webpack": "^5.10.3",
@@ -7991,8 +7991,8 @@
     "@piyoppi/pico2map-ui-components": {
       "version": "file:packages/map-editor-components",
       "requires": {
-        "@piyoppi/pico2map-editor": "0.0.18",
-        "@piyoppi/pico2map-tiled": "0.0.18",
+        "@piyoppi/pico2map-editor": "0.0.19",
+        "@piyoppi/pico2map-tiled": "0.0.19",
         "@types/jest": "^26.0.20",
         "jest": "^26.6.3",
         "lit-element": "^2.4.0",

--- a/packages/map-editor-components/package.json
+++ b/packages/map-editor-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piyoppi/pico2map-ui-components",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "pico2map Web Components",
   "main": "dist/main.js",
   "repository": {
@@ -18,8 +18,8 @@
     "ts-loader": "^8.0.14",
     "webpack": "^5.17.0",
     "webpack-cli": "^4.4.0",
-    "@piyoppi/pico2map-tiled": "0.0.18",
-    "@piyoppi/pico2map-editor": "0.0.18"
+    "@piyoppi/pico2map-tiled": "0.0.19",
+    "@piyoppi/pico2map-editor": "0.0.19"
   },
   "scripts": {
     "test": "jest",

--- a/packages/map-editor-components/src/AutoTileSelectorComponent.ts
+++ b/packages/map-editor-components/src/AutoTileSelectorComponent.ts
@@ -124,6 +124,8 @@ export class AutoTileSelectorComponent extends LitElement {
       <style>
         .grid {
           background-image: url("${this._gridImageSrc}");
+          width: ${this._indexImage.width}px;
+          height: ${this._indexImage.height}px;
         }
 
         .cursor {
@@ -161,8 +163,6 @@ export class AutoTileSelectorComponent extends LitElement {
         top: 0;
         left: 0;
         background-repeat: repeat;
-        width: 100%;
-        height: 100%;
       }
 
       .cursor, .selected {

--- a/packages/map-editor-components/src/AutoTileSelectorComponent.ts
+++ b/packages/map-editor-components/src/AutoTileSelectorComponent.ts
@@ -182,7 +182,7 @@ export class AutoTileSelectorComponent extends LitElement {
       }
 
       #boundary {
-        position: absolute;
+        position: relative;
       }
 
       #chip-image {

--- a/packages/map-editor-components/src/MapChipSelectorComponent.ts
+++ b/packages/map-editor-components/src/MapChipSelectorComponent.ts
@@ -183,7 +183,7 @@ export class MapChipSelectorComponent extends LitElement {
       }
 
       #boundary {
-        position: absolute;
+        position: relative;
       }
 
       #chip-image {

--- a/packages/map-editor-components/src/MapChipSelectorComponent.ts
+++ b/packages/map-editor-components/src/MapChipSelectorComponent.ts
@@ -125,6 +125,8 @@ export class MapChipSelectorComponent extends LitElement {
       <style>
         .grid {
           background-image: url("${this._gridImageSrc}");
+          width: ${this._chipImage?.image.width || 0}px;
+          height: ${this._chipImage?.image.height || 0}px;
         }
 
         .cursor {
@@ -162,8 +164,6 @@ export class MapChipSelectorComponent extends LitElement {
         top: 0;
         left: 0;
         background-repeat: repeat;
-        width: 100%;
-        height: 100%;
       }
 
       .cursor, .selected {

--- a/packages/map-editor-examples/package.json
+++ b/packages/map-editor-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piyoppi/pico2map-samples",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "",
   "main": "src/main.js",
   "directories": {
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "typescript": "^4.1.3",
-    "@piyoppi/pico2map-ui-components": "0.0.18",
-    "@piyoppi/pico2map-tiled": "0.0.18"
+    "@piyoppi/pico2map-ui-components": "0.0.19",
+    "@piyoppi/pico2map-tiled": "0.0.19"
   },
   "devDependencies": {
     "ts-loader": "^8.0.12",

--- a/packages/map-editor/package.json
+++ b/packages/map-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piyoppi/pico2map-editor",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "",
   "main": "dist/main.js",
   "repository": {
@@ -17,7 +17,7 @@
     "ts-loader": "^8.0.14",
     "webpack": "^5.17.0",
     "webpack-cli": "^4.4.0",
-    "@piyoppi/pico2map-tiled": "0.0.18"
+    "@piyoppi/pico2map-tiled": "0.0.19"
   },
   "scripts": {
     "test": "jest",

--- a/packages/tiled-map/package.json
+++ b/packages/tiled-map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@piyoppi/pico2map-tiled",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "",
   "main": "dist/main.js",
   "repository": {


### PR DESCRIPTION
`map-chip-selector-component` `auto-tile-selector-component` の外側要素のスタイルが `position: absolute` なので幅と高さが0になってしまうので修正する