### PR TITLE
マップ上をクリックしたタイミングでマップチップが配置されるようにします

### DIFF
--- a/packages/map-editor/src/MapCanvas.ts
+++ b/packages/map-editor/src/MapCanvas.ts
@@ -153,6 +153,8 @@ export class MapCanvas implements EditorCanvas {
     const chipPosition = this.convertFromCursorPositionToChipPosition(x, y)
     this._brush.mouseDown(chipPosition.x, chipPosition.y)
 
+    this._lastMapChipPosition = chipPosition
+
     this._paint(chipPosition)
   }
 

--- a/packages/map-editor/src/MapCanvas.ts
+++ b/packages/map-editor/src/MapCanvas.ts
@@ -153,7 +153,7 @@ export class MapCanvas implements EditorCanvas {
     const chipPosition = this.convertFromCursorPositionToChipPosition(x, y)
     this._brush.mouseDown(chipPosition.x, chipPosition.y)
 
-    this._lastMapChipPosition = chipPosition
+    this._paint(chipPosition)
   }
 
   mouseMove(x: number, y: number): {x: number, y: number} {
@@ -162,13 +162,7 @@ export class MapCanvas implements EditorCanvas {
     if (!this._isMouseDown) return chipPosition
     if (chipPosition.x === this._lastMapChipPosition.x && chipPosition.y === this._lastMapChipPosition.y) return chipPosition
 
-    this.clearSecondaryCanvas()
-    this._brush.mouseMove(chipPosition.x, chipPosition.y).forEach(paint => {
-      if (!this._secondaryCanvasCtx) return
-
-      const chip = paint.item
-      this.renderer.putOrClearChipToCanvas(this._secondaryCanvasCtx, chip, paint.x, paint.y, true)
-    })
+    this._paint(chipPosition)
 
     this._lastMapChipPosition = chipPosition
 
@@ -193,6 +187,16 @@ export class MapCanvas implements EditorCanvas {
   putChip(mapChip: MapChip | null, chipX: number, chipY: number) {
     this.project.tiledMap.put(mapChip, chipX, chipY, this._activeLayerIndex)
     this.renderer.putOrClearChipToCanvas(this._canvasContexts[this._activeLayerIndex], mapChip, chipX, chipY)
+  }
+
+  private _paint(chipPosition: {x: number, y: number}) {
+    this.clearSecondaryCanvas()
+    this._brush.mouseMove(chipPosition.x, chipPosition.y).forEach(paint => {
+      if (!this._secondaryCanvasCtx) return
+
+      const chip = paint.item
+      this.renderer.putOrClearChipToCanvas(this._secondaryCanvasCtx, chip, paint.x, paint.y, true)
+    })
   }
 
   private clearSecondaryCanvas() {

--- a/packages/map-editor/tests/MapCanvas.test.ts
+++ b/packages/map-editor/tests/MapCanvas.test.ts
@@ -1,6 +1,16 @@
 import { Projects } from './../src/Projects'
 import { MapCanvas } from './../src/MapCanvas'
 import { TiledMap } from '@piyoppi/pico2map-tiled'
+import { Brush } from './../src/Brushes/Brush'
+import { Arrangement } from '../src/Brushes/Arrangements/Arrangement'
+
+class EmptyBrush<T> implements Brush<T> {
+  setArrangement(_: Arrangement<T>) {}
+  mouseDown(_: number, __: number) {}
+  mouseMove(_: number, __: number) {return []}
+  mouseUp(_: number, __: number) {return []}
+  cleanUp() {}
+}
 
 describe('#setActiveLayer', () => {
   it('Should set an active layer', () => {
@@ -94,5 +104,24 @@ describe('#putChip', () => {
     mapCanvas.putChip(null, 1, 2)
     expect(tiledMap.put).toBeCalledWith(null, 1, 2, 1)
     expect(mapCanvas.renderer.putOrClearChipToCanvas).toBeCalledWith('dummy-context-layer1', null, 1, 2)
+  })
+})
+
+describe('#mouseDown', () => {
+  it('Should painted', () => {
+    const tiledMap = new TiledMap(30, 30, 32, 32)
+    const project = Projects.add(tiledMap)
+    const mapCanvas = new MapCanvas()
+    mapCanvas.setProject(project)
+
+    const brush = new EmptyBrush()
+    brush.mouseDown = jest.fn()
+    brush.mouseMove = jest.fn().mockReturnValue([])
+    mapCanvas.setBrush(brush)
+
+    mapCanvas.mouseDown(40, 70)
+
+    expect(brush.mouseDown).toBeCalledWith(1, 2)
+    expect(brush.mouseMove).toBeCalledWith(1, 2)
   })
 })


### PR DESCRIPTION
マップ上をクリックして1チップ分カーソルを動かさないとマップチップが配置されない不具合を修正しました。