### PR TITLE
マウスカーソルを押下したときはエディタの外側にカーソルがあったときでもマウス移動を追跡する

### DIFF
--- a/packages/map-editor-components/src/AutoTileSelectorComponent.ts
+++ b/packages/map-editor-components/src/AutoTileSelectorComponent.ts
@@ -198,6 +198,7 @@ export class AutoTileSelectorComponent extends LitElement {
 
       #chip-image {
         display: block;
+        user-select: none;
       }
     `
   }

--- a/packages/map-editor-components/src/MapCanvasComponent.ts
+++ b/packages/map-editor-components/src/MapCanvasComponent.ts
@@ -19,6 +19,9 @@ export class MapCanvasComponent extends LitElement {
   private _autoTileIdAttributeValue: number = -1
   private _inactiveLayerOpacity = 1.0
 
+  private _documentMouseMoveEventCallee: ((e: MouseEvent) => void) | null = null
+  private _documentMouseUpEventCallee: ((e: MouseEvent) => void) | null = null
+
   constructor() {
     super()
 
@@ -285,11 +288,23 @@ export class MapCanvasComponent extends LitElement {
   mouseDown(e: MouseEvent) {
     const mouseCursorPosition = this.cursorPositionCalculator.getMouseCursorPosition(e.pageX, e.pageY)
     this.currentEditorCanvas.mouseDown(mouseCursorPosition.x, mouseCursorPosition.y)
+
+    this._documentMouseMoveEventCallee = e => this.mouseMove(e)
+    this._documentMouseUpEventCallee = e => this.mouseUp(e)
+
+    document.addEventListener('mousemove', this._documentMouseMoveEventCallee)
+    document.addEventListener('mouseup', this._documentMouseUpEventCallee)
   }
 
   mouseUp(e: MouseEvent) {
     const mouseCursorPosition = this.cursorPositionCalculator.getMouseCursorPosition(e.pageX, e.pageY)
     this.currentEditorCanvas.mouseUp(mouseCursorPosition.x, mouseCursorPosition.y)
+
+    if (this._documentMouseMoveEventCallee) document.removeEventListener('mousemove', this._documentMouseMoveEventCallee)
+    if (this._documentMouseUpEventCallee) document.removeEventListener('mouseup', this._documentMouseUpEventCallee)
+
+    this._documentMouseMoveEventCallee = null
+    this._documentMouseUpEventCallee = null
   }
 
   render() {
@@ -335,9 +350,8 @@ export class MapCanvasComponent extends LitElement {
         ></canvas>
         <div
           class="grid-image grid"
-          @mousemove="${(e: MouseEvent) => this.mouseMove(e)}"
           @mousedown="${(e: MouseEvent) => this.mouseDown(e)}"
-          @mouseup ="${(e: MouseEvent) => this.mouseUp(e)}"
+          @mousemove="${(e: MouseEvent) => !this._mapCanvas.isMouseDown ? this.mouseMove(e) : null}"
         ></div>
         <div class="cursor"></div>
       </div>

--- a/packages/map-editor-components/src/MapChipSelectorComponent.ts
+++ b/packages/map-editor-components/src/MapChipSelectorComponent.ts
@@ -213,6 +213,7 @@ export class MapChipSelectorComponent extends LitElement {
 
       #chip-image {
         display: block;
+        user-select: none;
       }
     `
   }

--- a/packages/map-editor/src/MapCanvas.ts
+++ b/packages/map-editor/src/MapCanvas.ts
@@ -49,6 +49,10 @@ export class MapCanvas implements EditorCanvas {
     return this._activeLayerIndex
   }
 
+  get isMouseDown() {
+    return this._isMouseDown
+  }
+
   hasActiveAutoTile() {
     return !!this._selectedAutoTile
   }

--- a/packages/map-editor/tests/MapCanvas.test.ts
+++ b/packages/map-editor/tests/MapCanvas.test.ts
@@ -155,6 +155,7 @@ describe('#mouseDown', () => {
 
     mapCanvas.mouseDown(40, 70)
 
+    expect(mapCanvas.isMouseDown).toEqual(true)
     expect(brush.mouseDown).toBeCalledWith(1, 2)
     expect(brush.mouseMove).toBeCalledWith(1, 2)
   })


### PR DESCRIPTION
現状だと、マウスカーソルを押下したあとにエディタの外側にカーソルを移動すると、 `mouseMove` や `mouseUp` イベントを捕捉できないので挙動としてイマイチな状態になっている。

マウスカーソルを押下したら `document` の `mousemove` `mouseup` イベントを拾うことで、この挙動を解消する。