### PR TITLE
Coliderの編集周りの不具合を修正します

### DIFF
--- a/packages/map-editor-components/src/MapCanvasComponent.ts
+++ b/packages/map-editor-components/src/MapCanvasComponent.ts
@@ -138,11 +138,11 @@ export class MapCanvasComponent extends LitElement {
     this._mapCanvas.setMapChipFragments(mapChipFragments)
   }
 
-  @property({type: String})
+  @property({type: Number})
   get coliderType() {
-    return this._coliderCanvas.selectedColiderType || ''
+    return this._coliderCanvas.selectedColiderType
   }
-  set coliderType(value: ColiderTypes | '') {
+  set coliderType(value: ColiderTypes) {
     const oldValue = value
     this.requestUpdate('coliderType', oldValue);
 

--- a/packages/map-editor-components/src/MapCanvasComponent.ts
+++ b/packages/map-editor-components/src/MapCanvasComponent.ts
@@ -1,4 +1,5 @@
 import { LitElement, html, css, customElement, property } from 'lit-element'
+import { styleMap } from 'lit-html/directives/style-map';
 import { CursorPositionCalculator } from './Helpers/CursorPositionCalculator'
 import { GridImageGenerator, MapCanvas, Projects, Project, ColiderCanvas, EditorCanvas } from '@piyoppi/pico2map-editor'
 import { MapChipFragment, MapChipFragmentProperties } from '@piyoppi/pico2map-tiled'
@@ -31,6 +32,7 @@ export class MapCanvasComponent extends LitElement {
 
   @property({type: Number}) cursorChipX = 0
   @property({type: Number}) cursorChipY = 0
+  @property({type: Boolean}) hiddenColider = false
 
   @property({type: String})
   get gridColor(): string {
@@ -314,6 +316,10 @@ export class MapCanvasComponent extends LitElement {
       this.gridImageSrc = this.gridImageGenerator.generateLinePart().toDataURL()
     }
 
+    const coliderStyles = {
+      display: this.hiddenColider ? 'none' : 'block'
+    }
+
     return html`
       <style>
         .grid {
@@ -343,6 +349,7 @@ export class MapCanvasComponent extends LitElement {
           id="colider-canvas"
           width="${this.width}"
           height="${this.height}"
+          style="${styleMap(coliderStyles)}"
         ></canvas>
         <canvas
           id="secondary-canvas"

--- a/packages/map-editor-components/src/MapCanvasComponent.ts
+++ b/packages/map-editor-components/src/MapCanvasComponent.ts
@@ -338,12 +338,12 @@ export class MapCanvasComponent extends LitElement {
       </style>
 
       <div id="boundary">
+        <div id="canvases"></div>
         <canvas
           id="colider-canvas"
           width="${this.width}"
           height="${this.height}"
         ></canvas>
-        <div id="canvases"></div>
         <canvas
           id="secondary-canvas"
           width="${this.width}"

--- a/packages/map-editor-examples/simple_map_editor/index.html
+++ b/packages/map-editor-examples/simple_map_editor/index.html
@@ -35,6 +35,7 @@
             coliderType="colider"
             inactiveLayerOpacity="0.3"
             gridColor="#ccc"
+            hiddenColider
           ></map-canvas-component>
         </div>
         <div class="chip-selector">

--- a/packages/map-editor-examples/simple_map_editor/src/simple_map_editor.ts
+++ b/packages/map-editor-examples/simple_map_editor/src/simple_map_editor.ts
@@ -85,8 +85,8 @@ async function initialize() {
   })
 
   // Set an active colider type
-  coliderTypeNoneRadioButton.addEventListener('change', () => mapCanvas?.setAttribute('coliderType', 'none'))
-  coliderTypeColiderRadioButton.addEventListener('change', () => mapCanvas?.setAttribute('coliderType', 'colider'))
+  coliderTypeNoneRadioButton.addEventListener('change', () => mapCanvas?.setAttribute('coliderType', '0'))
+  coliderTypeColiderRadioButton.addEventListener('change', () => mapCanvas?.setAttribute('coliderType', '1'))
 
   autoTileSelector.addEventListener<any>('autotile-selected', (e: AutoTileSelectedEvent) => {
     // Set a AutoTileArrangement.

--- a/packages/map-editor-examples/simple_map_editor/src/simple_map_editor.ts
+++ b/packages/map-editor-examples/simple_map_editor/src/simple_map_editor.ts
@@ -74,12 +74,15 @@ async function initialize() {
   mapChipModeRadioButton.addEventListener('change', _ => {
     // Set arrangement map-chips mode
     mapCanvas.setAttribute('mode', 'mapChip')
+    mapCanvas.setAttribute('hiddenColider', 'true')
 
     coliderGroup.style.display = coliderModeRadioButton.checked ? 'block' : 'none'
   })
   coliderModeRadioButton?.addEventListener('change', _ => {
     // Set colider-edit mode
     mapCanvas.setAttribute('mode', 'colider')
+    mapCanvas.removeAttribute('hiddenColider')
+    console.log('changedddd')
 
     coliderGroup.style.display = coliderModeRadioButton.checked ? 'block' : 'none'
   })

--- a/packages/map-editor-examples/simple_map_editor/src/simple_map_editor.ts
+++ b/packages/map-editor-examples/simple_map_editor/src/simple_map_editor.ts
@@ -82,7 +82,6 @@ async function initialize() {
     // Set colider-edit mode
     mapCanvas.setAttribute('mode', 'colider')
     mapCanvas.removeAttribute('hiddenColider')
-    console.log('changedddd')
 
     coliderGroup.style.display = coliderModeRadioButton.checked ? 'block' : 'none'
   })

--- a/packages/map-editor/src/ColiderCanvas.ts
+++ b/packages/map-editor/src/ColiderCanvas.ts
@@ -66,6 +66,10 @@ export class ColiderCanvas implements EditorCanvas {
       if (!this._coliderCtx) return
       this.coliderRenderer.renderAll(this._coliderCtx)
     })
+
+    if (this._coliderCtx) {
+      this.coliderRenderer.renderAll(this._coliderCtx)
+    }
   }
 
   setCanvas(canvas: HTMLCanvasElement, secondaryCanvas: HTMLCanvasElement) {

--- a/packages/map-editor/src/ColiderCanvas.ts
+++ b/packages/map-editor/src/ColiderCanvas.ts
@@ -58,6 +58,10 @@ export class ColiderCanvas implements EditorCanvas {
     return this._secondaryCanvas
   }
 
+  get isMouseDown() {
+    return this._isMouseDown
+  }
+
   setProject(project: Project) {
     this._project = project
     this._coliderRenderer = new ColiderRenderer(this._project.tiledMap)

--- a/packages/map-editor/src/ColiderCanvas.ts
+++ b/packages/map-editor/src/ColiderCanvas.ts
@@ -98,6 +98,8 @@ export class ColiderCanvas implements EditorCanvas {
     const chipPosition = this.convertFromCursorPositionToChipPosition(x, y)
     this._brush.mouseDown(chipPosition.x, chipPosition.y)
 
+    this._paint(chipPosition)
+
     this._lastMapChipPosition = chipPosition
   }
 
@@ -107,11 +109,7 @@ export class ColiderCanvas implements EditorCanvas {
     if (!this._isMouseDown) return chipPosition
     if (chipPosition.x === this._lastMapChipPosition.x && chipPosition.y === this._lastMapChipPosition.y) return chipPosition
 
-    this.clearSecondaryCanvas()
-    this._brush.mouseMove(chipPosition.x, chipPosition.y).forEach(paint => {
-      const chip = paint.item
-      this.coliderRenderer.putOrClearChipToCanvas(this.secondaryCanvasCtx, chip, paint.x, paint.y, true)
-    })
+    this._paint(chipPosition)
 
     this._lastMapChipPosition = chipPosition
 
@@ -131,6 +129,14 @@ export class ColiderCanvas implements EditorCanvas {
     this.clearSecondaryCanvas()
     this._brush.cleanUp()
     this._lastMapChipPosition = {x: -1, y: -1}
+  }
+
+  private _paint(chipPosition: {x: number, y: number}) {
+    this.clearSecondaryCanvas()
+    this._brush.mouseMove(chipPosition.x, chipPosition.y).forEach(paint => {
+      const chip = paint.item
+      this.coliderRenderer.putOrClearChipToCanvas(this.secondaryCanvasCtx, chip, paint.x, paint.y, true)
+    })
   }
 
   putChip(coliderType: ColiderTypes, chipX: number, chipY: number) {

--- a/packages/map-editor/tests/ColiderCanvas.test.ts
+++ b/packages/map-editor/tests/ColiderCanvas.test.ts
@@ -1,0 +1,48 @@
+import { Projects } from './../src/Projects'
+import { ColiderCanvas } from './../src/ColiderCanvas'
+import { TiledMap } from '@piyoppi/pico2map-tiled'
+import { ColiderRenderer } from './../src/ColiderRenderer'
+import { mocked } from 'ts-jest/utils'
+import { createMockedCanvas } from './TestHelpers/MockedCanvas'
+import { EmptyBrush } from './TestHelpers/EmptyBrush'
+
+jest.mock('./../src/ColiderRenderer')
+
+beforeEach(() => {
+  mocked(ColiderRenderer).mockClear()
+})
+
+const tiledMap = new TiledMap(30, 30, 32, 32)
+
+describe('#setProject', () => {
+  it('Should call renderAll function', () => {
+    const project = Projects.add(tiledMap)
+    const coliderCanvas = new ColiderCanvas()
+    coliderCanvas.setCanvas(createMockedCanvas() as any, createMockedCanvas() as any)
+
+    coliderCanvas.setProject(project)
+
+    const mockedRendererInstance = mocked(ColiderRenderer).mock.instances[0]
+    expect(mockedRendererInstance.renderAll).toBeCalled()
+  })
+})
+
+describe('#mouseDown', () => {
+  it('Should painted', () => {
+    const project = Projects.add(tiledMap)
+    const coliderCanvas = new ColiderCanvas()
+    coliderCanvas.setCanvas(createMockedCanvas() as any, createMockedCanvas() as any)
+    coliderCanvas.setProject(project)
+
+    const brush = new EmptyBrush()
+    brush.mouseDown = jest.fn()
+    brush.mouseMove = jest.fn().mockReturnValue([])
+    coliderCanvas.setBrush(brush)
+
+    coliderCanvas.mouseDown(40, 70)
+
+    expect(coliderCanvas.isMouseDown).toEqual(true)
+    expect(brush.mouseDown).toBeCalledWith(1, 2)
+    expect(brush.mouseMove).toBeCalledWith(1, 2)
+  })
+})

--- a/packages/map-editor/tests/MapCanvas.test.ts
+++ b/packages/map-editor/tests/MapCanvas.test.ts
@@ -1,21 +1,8 @@
 import { Projects } from './../src/Projects'
 import { MapCanvas } from './../src/MapCanvas'
 import { TiledMap } from '@piyoppi/pico2map-tiled'
-import { Brush, BrushPaint } from './../src/Brushes/Brush'
-import { Arrangement, ArrangementPaint } from '../src/Brushes/Arrangements/Arrangement'
-
-class EmptyBrush<T> implements Brush<T> {
-  setArrangement(_: Arrangement<T>) {}
-  mouseDown(_: number, __: number) {}
-  mouseMove(_: number, __: number) {return []}
-  mouseUp(_: number, __: number) {return []}
-  cleanUp() {}
-}
-
-class EmptyArrangement<T> implements Arrangement<T> {
-  setMapChips(_: Array<T>) {}
-  apply(_: Array<BrushPaint>): Array<ArrangementPaint<T>> { return [] }
-}
+import { EmptyBrush } from './TestHelpers/EmptyBrush'
+import { EmptyArrangement } from './TestHelpers/EmptyArrangement'
 
 let mockedCanvas = {}
 let mockedCanvasLayer1 = {}

--- a/packages/map-editor/tests/TestHelpers/EmptyArrangement.ts
+++ b/packages/map-editor/tests/TestHelpers/EmptyArrangement.ts
@@ -1,0 +1,8 @@
+import { Arrangement, ArrangementPaint } from '../../src/Brushes/Arrangements/Arrangement'
+import { BrushPaint } from './../../src/Brushes/Brush'
+
+export class EmptyArrangement<T> implements Arrangement<T> {
+  setMapChips(_: Array<T>) {}
+  apply(_: Array<BrushPaint>): Array<ArrangementPaint<T>> { return [] }
+}
+

--- a/packages/map-editor/tests/TestHelpers/EmptyBrush.ts
+++ b/packages/map-editor/tests/TestHelpers/EmptyBrush.ts
@@ -1,0 +1,10 @@
+import { Brush } from './../../src/Brushes/Brush'
+import { Arrangement } from '../../src/Brushes/Arrangements/Arrangement'
+
+export class EmptyBrush<T> implements Brush<T> {
+  setArrangement(_: Arrangement<T>) {}
+  mouseDown(_: number, __: number) {}
+  mouseMove(_: number, __: number) {return []}
+  mouseUp(_: number, __: number) {return []}
+  cleanUp() {}
+}

--- a/packages/map-editor/tests/TestHelpers/MockedCanvas.ts
+++ b/packages/map-editor/tests/TestHelpers/MockedCanvas.ts
@@ -1,0 +1,11 @@
+function createMockedCanvasContext() {
+  return {
+    clearRect: jest.fn()
+  }
+}
+
+export function createMockedCanvas() {
+  return {
+    getContext: jest.fn().mockReturnValueOnce(createMockedCanvasContext()),
+  }
+}


### PR DESCRIPTION
- https://github.com/piyoppi/pico2map/pull/21 によってColiderTypesの型を変更したことによってColiderを配置できない状態になってしまったので直す
- Coliderの編集結果がマップチップに隠れて表示されないのでキャンバスの前後関係を調整する
- マップを読み込んだときにColiderが描画されるようにする