### PR TITLE
ColiderCanvasにキャンバスを設定したときに描画可能なら全体を描画する

### DIFF
--- a/packages/map-editor/src/ColiderCanvas.ts
+++ b/packages/map-editor/src/ColiderCanvas.ts
@@ -81,6 +81,10 @@ export class ColiderCanvas implements EditorCanvas {
     this._coliderCtx = canvas.getContext('2d') as CanvasRenderingContext2D
     this._secondaryCanvasCtx = secondaryCanvas.getContext('2d') as CanvasRenderingContext2D
     this._secondaryCanvas = secondaryCanvas
+
+    if (this._coliderRenderer) {
+      this.coliderRenderer.renderAll(this._coliderCtx)
+    }
   }
 
   setBrush(brush: Brush<ColiderTypes>) {

--- a/packages/map-editor/src/ColiderCanvas.ts
+++ b/packages/map-editor/src/ColiderCanvas.ts
@@ -63,16 +63,20 @@ export class ColiderCanvas implements EditorCanvas {
     return this._isMouseDown
   }
 
+  get renderable() {
+    return !!this._coliderCtx && !!this._coliderRenderer
+  }
+
   setProject(project: Project) {
     this._project = project
     this._coliderRenderer = new ColiderRenderer(this._project.tiledMap)
 
     this._project.registerRenderAllCallback(() => {
-      if (!this._coliderCtx) return
+      if (!this.renderable || !this._coliderCtx) return
       this.coliderRenderer.renderAll(this._coliderCtx)
     })
 
-    if (this._coliderCtx) {
+    if (this.renderable && this._coliderCtx) {
       this.coliderRenderer.renderAll(this._coliderCtx)
     }
   }
@@ -82,7 +86,7 @@ export class ColiderCanvas implements EditorCanvas {
     this._secondaryCanvasCtx = secondaryCanvas.getContext('2d') as CanvasRenderingContext2D
     this._secondaryCanvas = secondaryCanvas
 
-    if (this._coliderRenderer) {
+    if (this.renderable) {
       this.coliderRenderer.renderAll(this._coliderCtx)
     }
   }

--- a/packages/map-editor/src/MapCanvas.ts
+++ b/packages/map-editor/src/MapCanvas.ts
@@ -53,6 +53,10 @@ export class MapCanvas implements EditorCanvas {
     return this._isMouseDown
   }
 
+  get renderable() {
+    return this._canvasContexts.length > 0 && !!this._renderer
+  }
+
   hasActiveAutoTile() {
     return !!this._selectedAutoTile
   }
@@ -64,11 +68,14 @@ export class MapCanvas implements EditorCanvas {
     this._project.registerRenderAllCallback(() => this.renderAll())
 
     await this._project.tiledMap.mapChipsCollection.waitWhileLoading()
-    this.renderAll()
+
+    if (this.renderable) {
+      this.renderAll()
+    }
   }
 
   renderAll() {
-    if (!this._renderer) return
+    if (!this.renderable) return
     const renderer = this.renderer
     this._canvasContexts.forEach((ctx, index) => renderer.renderLayer(index, ctx))
   }
@@ -78,6 +85,10 @@ export class MapCanvas implements EditorCanvas {
     this._canvasContexts = this._canvases.map(canvas => canvas.getContext('2d') as CanvasRenderingContext2D)
     this.secondaryCanvas = secondaryCanvas
     this._secondaryCanvasCtx = this.secondaryCanvas.getContext('2d') as CanvasRenderingContext2D
+
+    if (this.renderable) {
+      this.renderAll()
+    }
   }
 
   addCanvas(canvas: HTMLCanvasElement) {

--- a/packages/map-editor/tests/ColiderCanvas.test.ts
+++ b/packages/map-editor/tests/ColiderCanvas.test.ts
@@ -14,16 +14,62 @@ beforeEach(() => {
 
 const tiledMap = new TiledMap(30, 30, 32, 32)
 
+describe('rendererable', () => {
+  it('Should return true when projectId and canvas is given', () => {
+    const project = Projects.add(tiledMap)
+    const coliderCanvas = new ColiderCanvas()
+    coliderCanvas.setCanvas(createMockedCanvas() as any, createMockedCanvas() as any)
+    coliderCanvas.setProject(project)
+
+    expect(coliderCanvas.renderable).toEqual(true)
+  })
+
+  it('Should return false when projectId is not given', () => {
+    const coliderCanvas = new ColiderCanvas()
+    coliderCanvas.setCanvas(createMockedCanvas() as any, createMockedCanvas() as any)
+
+    expect(coliderCanvas.renderable).toEqual(false)
+  })
+
+  it('Should return false when canvas is not given', () => {
+    const project = Projects.add(tiledMap)
+    const coliderCanvas = new ColiderCanvas()
+    coliderCanvas.setProject(project)
+
+    expect(coliderCanvas.renderable).toEqual(false)
+  })
+})
+
 describe('#setProject', () => {
   it('Should call renderAll function', () => {
     const project = Projects.add(tiledMap)
     const coliderCanvas = new ColiderCanvas()
     coliderCanvas.setCanvas(createMockedCanvas() as any, createMockedCanvas() as any)
-
     coliderCanvas.setProject(project)
 
     const mockedRendererInstance = mocked(ColiderRenderer).mock.instances[0]
-    expect(mockedRendererInstance.renderAll).toBeCalled()
+    expect(mockedRendererInstance.renderAll).toBeCalledTimes(1)
+  })
+
+  it('Should not call renderAll function when the canvas is not given.', () => {
+    const project = Projects.add(tiledMap)
+    const coliderCanvas = new ColiderCanvas()
+    coliderCanvas.setProject(project)
+
+    const mockedRendererInstance = mocked(ColiderRenderer).mock.instances[0]
+    expect(mockedRendererInstance.renderAll).not.toBeCalled()
+  })
+})
+
+describe('setCanvas', () => {
+  it('Should call renderAll function when projectId is already set.', () => {
+    const project = Projects.add(tiledMap)
+    const coliderCanvas = new ColiderCanvas()
+    coliderCanvas.setProject(project)
+    coliderCanvas.setCanvas(createMockedCanvas() as any, createMockedCanvas() as any)
+
+    const mockedRendererInstance = mocked(ColiderRenderer).mock.instances[0]
+    expect(mockedRendererInstance.renderAll).toBeCalledTimes(1)
   })
 })
 

--- a/packages/map-editor/tests/MapCanvas.test.ts
+++ b/packages/map-editor/tests/MapCanvas.test.ts
@@ -69,9 +69,45 @@ describe('#setProject', () => {
     const mapCanvas = new MapCanvas()
     mapCanvas.renderAll = jest.fn()
 
+    mapCanvas.setCanvases([mockedCanvas, mockedCanvasLayer1] as any, mockedSecondaryCanvas as any)
     await mapCanvas.setProject(project)
 
-    expect(mapCanvas.renderAll).toBeCalled()
+    expect(mapCanvas.renderAll).toBeCalledTimes(1)
+  })
+
+  it('Should not call renderAll function when canvases are not set', async () => {
+    const tiledMap = new TiledMap(30, 30, 32, 32)
+    const project = Projects.add(tiledMap)
+    const mapCanvas = new MapCanvas()
+    mapCanvas.renderAll = jest.fn()
+
+    await mapCanvas.setProject(project)
+
+    expect(mapCanvas.renderAll).not.toBeCalledTimes(1)
+  })
+})
+
+describe('#setCanvases', () => {
+  it('Should call rendering function when projectId is already set.', async () => {
+    const tiledMap = new TiledMap(30, 30, 32, 32)
+    const project = Projects.add(tiledMap)
+    const mapCanvas = new MapCanvas()
+    mapCanvas.renderAll = jest.fn()
+
+    await mapCanvas.setProject(project)
+    mapCanvas.setCanvases([mockedCanvas, mockedCanvasLayer1] as any, mockedSecondaryCanvas as any)
+
+    expect(mapCanvas.renderAll).toBeCalledTimes(1)
+  })
+
+  it('Should not call rendering function when projectId is not given.', async () => {
+    const tiledMap = new TiledMap(30, 30, 32, 32)
+    const mapCanvas = new MapCanvas()
+    mapCanvas.renderAll = jest.fn()
+
+    mapCanvas.setCanvases([mockedCanvas, mockedCanvasLayer1] as any, mockedSecondaryCanvas as any)
+
+    expect(mapCanvas.renderAll).not.toBeCalled()
   })
 })
 
@@ -85,6 +121,8 @@ describe('#renderAll', () => {
     mapCanvas.renderer.renderLayer = jest.fn()
     mapCanvas.setCanvases([mockedCanvas, mockedCanvasLayer1] as any, mockedSecondaryCanvas as any)
 
+    // Reset renderLayer mock because renderAll is invoked by `mapCanvas.setCanvases`
+    mapCanvas.renderer.renderLayer = jest.fn()
     mapCanvas.renderAll()
 
     expect(mapCanvas.renderer.renderLayer).toBeCalledTimes(2)
@@ -96,6 +134,7 @@ describe('#putChip', () => {
     const tiledMap = new TiledMap(30, 30, 32, 32)
     const project = Projects.add(tiledMap)
     const mapCanvas = new MapCanvas()
+    mapCanvas.renderAll = jest.fn()
     mapCanvas.setProject(project)
 
     mapCanvas.setCanvases([mockedCanvas] as any, mockedSecondaryCanvas as any)
@@ -113,6 +152,7 @@ describe('#putChip', () => {
     tiledMap.addLayer()
     const project = Projects.add(tiledMap)
     const mapCanvas = new MapCanvas()
+    mapCanvas.renderAll = jest.fn()
     mapCanvas.setProject(project)
 
     mapCanvas.setCanvases([mockedCanvas, mockedCanvasLayer1] as any, mockedSecondaryCanvas as any)
@@ -132,6 +172,7 @@ describe('#mouseDown', () => {
     const tiledMap = new TiledMap(30, 30, 32, 32)
     const project = Projects.add(tiledMap)
     const mapCanvas = new MapCanvas()
+    mapCanvas.renderAll = jest.fn()
     mapCanvas.setProject(project)
     mapCanvas.setArrangement(new EmptyArrangement())
 


### PR DESCRIPTION
ColiderCanvasに `projectId` Attributeを設定したとき、Coliderが描画されない不具合があるので修正する