### PR TITLE
MapPaletteMatrixを実装してマップデータをMapMatrixから置き換えます

### DIFF
--- a/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
+++ b/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
@@ -33,7 +33,7 @@ export class MapPaletteMatrix<T> {
     return this._values.height
   }
 
-  get items(): Array<T | null> {
+  get items(): Array<MapPaletteMatrixItem<T>> {
     return this._values.items.map(value => value >= 0 ? this._palette[value] : null)
   }
 
@@ -88,6 +88,13 @@ export class MapPaletteMatrix<T> {
     cloned.setValuePalette(this._values.items, this._palette)
 
     return cloned
+  }
+
+  rebuild() {
+    const items = this.items
+    this._palette = []
+    this._paletteIndexes.clear()
+    this.set(items)
   }
 
   private _getPaletteIndexFromValue(value: MapPaletteMatrixItem<T>): number {

--- a/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
+++ b/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
@@ -1,0 +1,104 @@
+import { transferEach } from './TransferEach'
+import { MapMatrix } from './MapMatrix'
+import { MapChipComparable } from '../MapChip'
+
+type MapPaletteMatrixItem = MapChipComparable | null
+
+export class MapPaletteMatrix {
+  private _paletteIndexes: Map<string, number> = new Map()
+
+  constructor(
+    chipCountX: number,
+    chipCountY: number,
+    items: Array<MapPaletteMatrixItem> = [],
+    private _palette: Array<MapPaletteMatrixItem> = [],
+    private _values = new MapMatrix<number>(chipCountX, chipCountY, new Array(chipCountY * chipCountX).fill(-1))
+  ) {
+    if (items.length > 0) {
+      this.set(items)
+    }
+  }
+
+  get size() {
+    return this._values.size
+  }
+
+  get width() {
+    return this._values.width
+  }
+
+  get height() {
+    return this._values.height
+  }
+
+  get items() {
+    return this._values.items.map(value => value >= 0 ? this._palette[value] : null)
+  }
+
+  get palette() {
+    return this._palette
+  }
+
+  get values() {
+    return this._values
+  }
+
+  set(items: Array<MapPaletteMatrixItem>) {
+    if (items.length !== this._values.items.length) throw new Error()
+
+    this._values.set(items.map(value => this._getPaletteIndexFromValue(value)))
+  }
+
+  setValuePalette(values: Array<number>, palette: Array<MapPaletteMatrixItem>) {
+    if (values.length !== this._values.items.length) throw new Error()
+
+    this._values.set(values)
+    this._palette = palette
+  }
+
+  transferFromTiledMapData(src: MapPaletteMatrix, srcX: number, srcY: number, width: number, height: number, destX: number, destY: number) {
+    transferEach(
+      srcX, srcY, width, height, destX, destY,
+      src.width, src.height, this.width, this.height,
+      (pickupX, pickupY, putX, putY) => {
+        const item = src.getFromChipPosition(pickupX, pickupY)
+        this._values.put(this._getPaletteIndexFromValue(item), putX, putY)
+      }
+    )
+  }
+
+  resize(chipCountX: number, chipCountY: number, emptyValue: MapPaletteMatrixItem) {
+    this._values.resize(chipCountX, chipCountY, this._getPaletteIndexFromValue(emptyValue))
+  }
+
+  getFromChipPosition(x: number, y: number): MapPaletteMatrixItem {
+    const paletteIndex = this._values.getFromChipPosition(x, y)
+
+    return paletteIndex >= 0 ? this._palette[paletteIndex] : null
+  }
+
+  put(item: MapPaletteMatrixItem, x: number, y: number) {
+    this._values.put(this._getPaletteIndexFromValue(item), x, y)
+  }
+
+  clone() {
+    const cloned = new MapPaletteMatrix(this.width, this.height)
+    cloned.setValuePalette(this._values.items, this._palette)
+
+    return cloned
+  }
+
+  private _getPaletteIndexFromValue(value: MapPaletteMatrixItem): number {
+    if (value === null) return -1
+
+    const index = this._paletteIndexes.get(value.identifyKey)
+    if (index !== undefined) return index
+
+    this._palette.push(value)
+
+    const addedIndex = this._palette.length - 1
+    this._paletteIndexes.set(value.identifyKey, addedIndex)
+
+    return addedIndex
+  }
+}

--- a/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
+++ b/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
@@ -6,14 +6,16 @@ type MapPaletteMatrixItem<T> = (T & MapChipComparable) | null
 
 export class MapPaletteMatrix<T> {
   private _paletteIndexes: Map<string, number> = new Map()
+  private _values = new MapMatrix<number>(0, 0, [])
+  private _palette: Array<MapPaletteMatrixItem<T>> = []
 
   constructor(
     chipCountX: number,
     chipCountY: number,
     items: Array<MapPaletteMatrixItem<T>> = [],
-    private _palette: Array<MapPaletteMatrixItem<T>> = [],
-    private _values = new MapMatrix<number>(chipCountX, chipCountY, new Array(chipCountY * chipCountX).fill(-1))
   ) {
+    this._values = new MapMatrix<number>(chipCountX, chipCountY, new Array(chipCountY * chipCountX).fill(-1))
+
     if (items.length > 0) {
       this.set(items)
     }

--- a/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
+++ b/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
@@ -2,16 +2,16 @@ import { transferEach } from './TransferEach'
 import { MapMatrix } from './MapMatrix'
 import { MapChipComparable } from '../MapChip'
 
-type MapPaletteMatrixItem = MapChipComparable | null
+type MapPaletteMatrixItem<T> = (T & MapChipComparable) | null
 
-export class MapPaletteMatrix {
+export class MapPaletteMatrix<T> {
   private _paletteIndexes: Map<string, number> = new Map()
 
   constructor(
     chipCountX: number,
     chipCountY: number,
-    items: Array<MapPaletteMatrixItem> = [],
-    private _palette: Array<MapPaletteMatrixItem> = [],
+    items: Array<MapPaletteMatrixItem<T>> = [],
+    private _palette: Array<MapPaletteMatrixItem<T>> = [],
     private _values = new MapMatrix<number>(chipCountX, chipCountY, new Array(chipCountY * chipCountX).fill(-1))
   ) {
     if (items.length > 0) {
@@ -31,7 +31,7 @@ export class MapPaletteMatrix {
     return this._values.height
   }
 
-  get items() {
+  get items(): Array<T | null> {
     return this._values.items.map(value => value >= 0 ? this._palette[value] : null)
   }
 
@@ -43,20 +43,20 @@ export class MapPaletteMatrix {
     return this._values
   }
 
-  set(items: Array<MapPaletteMatrixItem>) {
+  set(items: Array<MapPaletteMatrixItem<T>>) {
     if (items.length !== this._values.items.length) throw new Error()
 
     this._values.set(items.map(value => this._getPaletteIndexFromValue(value)))
   }
 
-  setValuePalette(values: Array<number>, palette: Array<MapPaletteMatrixItem>) {
+  setValuePalette(values: Array<number>, palette: Array<MapPaletteMatrixItem<T>>) {
     if (values.length !== this._values.items.length) throw new Error()
 
     this._values.set(values)
     this._palette = palette
   }
 
-  transferFromTiledMapData(src: MapPaletteMatrix, srcX: number, srcY: number, width: number, height: number, destX: number, destY: number) {
+  transferFromTiledMapData(src: MapPaletteMatrix<T>, srcX: number, srcY: number, width: number, height: number, destX: number, destY: number) {
     transferEach(
       srcX, srcY, width, height, destX, destY,
       src.width, src.height, this.width, this.height,
@@ -67,17 +67,17 @@ export class MapPaletteMatrix {
     )
   }
 
-  resize(chipCountX: number, chipCountY: number, emptyValue: MapPaletteMatrixItem) {
+  resize(chipCountX: number, chipCountY: number, emptyValue: MapPaletteMatrixItem<T>) {
     this._values.resize(chipCountX, chipCountY, this._getPaletteIndexFromValue(emptyValue))
   }
 
-  getFromChipPosition(x: number, y: number): MapPaletteMatrixItem {
+  getFromChipPosition(x: number, y: number): MapPaletteMatrixItem<T> {
     const paletteIndex = this._values.getFromChipPosition(x, y)
 
     return paletteIndex >= 0 ? this._palette[paletteIndex] : null
   }
 
-  put(item: MapPaletteMatrixItem, x: number, y: number) {
+  put(item: MapPaletteMatrixItem<T>, x: number, y: number) {
     this._values.put(this._getPaletteIndexFromValue(item), x, y)
   }
 
@@ -88,7 +88,7 @@ export class MapPaletteMatrix {
     return cloned
   }
 
-  private _getPaletteIndexFromValue(value: MapPaletteMatrixItem): number {
+  private _getPaletteIndexFromValue(value: MapPaletteMatrixItem<T>): number {
     if (value === null) return -1
 
     const index = this._paletteIndexes.get(value.identifyKey)

--- a/packages/tiled-map/src/MapData/TiledMapData.ts
+++ b/packages/tiled-map/src/MapData/TiledMapData.ts
@@ -1,5 +1,5 @@
 import { MapChip, MapChipProperties,  AutoTileMapChipProperties, isAutoTileMapChipProperties, AutoTileMapChip } from './../MapChip'
-import { MapMatrix } from './MapMatrix'
+import { MapPaletteMatrix } from './MapPaletteMatrix'
 
 export type TiledMapDataItem = MapChip | null
 
@@ -9,9 +9,9 @@ export type TiledMapDataProperties = {
   mapData: Array<MapChipProperties | AutoTileMapChipProperties | null>
 }
 
-export class TiledMapData extends MapMatrix<TiledMapDataItem> {
+export class TiledMapData extends MapPaletteMatrix<TiledMapDataItem> {
   filter(needles: Array<MapChip>): TiledMapData {
-    const filtered = this._items.map(chip => needles.some(needle => !!chip && needle.compare(chip)) ? chip : null)
+    const filtered = this.items.map(chip => needles.some(needle => !!chip && needle.compare(chip)) ? chip : null)
     return new TiledMapData(
       this.width,
       this.height,
@@ -21,9 +21,9 @@ export class TiledMapData extends MapMatrix<TiledMapDataItem> {
 
   toObject(): TiledMapDataProperties {
     return {
-      chipCountX: this._chipCountX,
-      chipCountY: this._chipCountY,
-      mapData: this._items.map(data => data?.toObject() || null)
+      chipCountX: this.width,
+      chipCountY: this.height,
+      mapData: this.items.map(data => data ? (data as MapChip).toObject() : null)
     }
   }
 

--- a/packages/tiled-map/src/MapData/TiledMapData.ts
+++ b/packages/tiled-map/src/MapData/TiledMapData.ts
@@ -6,7 +6,8 @@ export type TiledMapDataItem = MapChip | null
 export type TiledMapDataProperties = {
   chipCountX: number,
   chipCountY: number,
-  mapData: Array<MapChipProperties | AutoTileMapChipProperties | null>
+  values: Array<number>
+  palette: Array<MapChipProperties | AutoTileMapChipProperties | null>
 }
 
 export class TiledMapData extends MapPaletteMatrix<TiledMapDataItem> {
@@ -23,12 +24,13 @@ export class TiledMapData extends MapPaletteMatrix<TiledMapDataItem> {
     return {
       chipCountX: this.width,
       chipCountY: this.height,
-      mapData: this.items.map(data => data ? (data as MapChip).toObject() : null)
+      values: this.values.items,
+      palette: this.palette.map(data => data ? (data as MapChip).toObject() : null)
     }
   }
 
   static fromObject(val: TiledMapDataProperties) {
-    const mapData = val.mapData.map(data => {
+    const palette = val.palette.map(data => {
       if (!data) return null
 
       if (isAutoTileMapChipProperties(data)) {
@@ -36,9 +38,11 @@ export class TiledMapData extends MapPaletteMatrix<TiledMapDataItem> {
       }
 
       return MapChip.fromObject(data)
-
     })
 
-    return new TiledMapData(val.chipCountX, val.chipCountY, mapData)
+    const tiledMapData = new TiledMapData(val.chipCountX, val.chipCountY, [])
+    tiledMapData.setValuePalette(val.values, palette)
+
+    return tiledMapData
   }
 }

--- a/packages/tiled-map/src/MapData/TransferEach.ts
+++ b/packages/tiled-map/src/MapData/TransferEach.ts
@@ -1,0 +1,28 @@
+export function transferEach(
+  srcX: number,
+  srcY: number,
+  width: number,
+  height: number,
+  destX: number,
+  destY: number,
+  srcWidth: number,
+  srcHeight: number,
+  destWidth: number,
+  destHeight: number,
+  callback: (pickupX: number, pickupY: number, putX: number, putY: number) => void) {
+    for(let x = 0; x < width; x++) {
+      const putX = destX + x
+      const pickupX = srcX + x
+      if (putX < 0 || putX >= destWidth) continue;
+      if (pickupX < 0 || pickupX >= srcWidth) continue;
+
+      for(let y = 0; y < height; y++) {
+        const putY = destY + y
+        const pickupY = srcY + y
+        if (putY < 0 || putY >= destHeight) continue;
+        if (pickupY < 0 || pickupY >= srcHeight) continue;
+
+        callback(pickupX, pickupY, putX, putY)
+      }
+    }
+  }

--- a/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
+++ b/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
@@ -155,3 +155,99 @@ describe('#getFromChipPosition', () => {
     expect(data.getFromChipPosition(1, 2)).toEqual(c[0])
   })
 })
+
+describe('#clone', () => {
+  it('Should return a cloned value', () => {
+    const source = [
+      c[1], c[0], c[2],
+      c[2], c[2], c[1],
+      c[1], null, c[1],
+    ]
+    const data = new MapPaletteMatrix(3, 3, source)
+
+    const cloned = data.clone()
+    expect(data).not.toEqual(cloned)
+    expect(data.width).toEqual(cloned.width)
+    expect(data.height).toEqual(cloned.height)
+    expect(data.values.items).toEqual(cloned.values.items)
+    expect(data.palette).toEqual(cloned.palette)
+  })
+})
+
+describe('#setValuePalette', () => {
+  it('Should set values and the palette', () => {
+    const data = new MapPaletteMatrix(3, 3)
+    data.setValuePalette(
+      [
+        0,  1, 2,
+        2,  2, 0,
+        0, -1, 0
+      ],
+      [c[1], c[0], c[2]]
+    )
+
+    expect(data.values.items).toEqual([
+      0,  1, 2,
+      2,  2, 0,
+      0, -1, 0
+    ])
+    expect(data.palette).toEqual([c[1], c[0], c[2]])
+  })
+})
+
+describe('#set', () => {
+  it('Should set values and a palette using source values', () => {
+    const data = new MapPaletteMatrix(3, 3)
+    const source = [
+      c[1], c[0], c[2],
+      c[2], c[2], c[1],
+      c[1], null, c[1],
+    ]
+    data.set(source)
+
+    expect(data.values.items).toEqual([
+      0,  1, 2,
+      2,  2, 0,
+      0, -1, 0
+    ])
+    expect(data.palette).toEqual([c[1], c[0], c[2]])
+  })
+})
+
+describe('.items', () => {
+  it('Should return generated values using palette and values', () => {
+    const data = new MapPaletteMatrix(3, 3)
+    data.setValuePalette(
+      [
+        0,  1, 2,
+        2,  2, 0,
+        0, -1, 0
+      ],
+      [c[1], c[0], c[2]]
+    )
+
+    expect(data.items).toEqual([
+      c[1], c[0], c[2],
+      c[2], c[2], c[1],
+      c[1], null, c[1],
+    ])
+  })
+})
+
+describe('palette and values', () => {
+  it('Should set palette and values', () => {
+    const source = [
+      c[1], c[0], c[2],
+      c[2], c[2], c[1],
+      c[1], null, c[1],
+    ]
+    const data = new MapPaletteMatrix(3, 3, source)
+
+    expect(data.values.items).toEqual([
+      0,  1, 2,
+      2,  2, 0,
+      0, -1, 0
+    ])
+    expect(data.palette).toEqual([c[1], c[0], c[2]])
+  })
+})

--- a/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
+++ b/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
@@ -5,6 +5,8 @@ const c = [
   new MapChip([new MapChipFragment(0, 0, 0)]),
   new MapChip([new MapChipFragment(1, 0, 0)]),
   new MapChip([new MapChipFragment(2, 0, 0)]),
+  new MapChip([new MapChipFragment(3, 0, 0)]),
+  new MapChip([new MapChipFragment(4, 0, 0)]),
 ]
 
 describe('resize', () => {
@@ -249,5 +251,28 @@ describe('palette and values', () => {
       0, -1, 0
     ])
     expect(data.palette).toEqual([c[1], c[0], c[2]])
+  })
+})
+
+describe('#rebuild', () => {
+  it('Should rebuild a palette and values', () => {
+    const data = new MapPaletteMatrix(3, 3)
+    data.setValuePalette(
+      [
+        1,  2, 4,
+        4,  4, 1,
+        1, -1, 1
+      ],
+      [c[0], c[1], c[2], c[3], c[4]]
+    )
+
+    data.rebuild()
+
+    expect(data.values.items).toEqual([
+      0,  1, 2,
+      2,  2, 0,
+      0, -1, 0
+    ])
+    expect(data.palette).toEqual([c[1], c[2], c[4]])
   })
 })

--- a/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
+++ b/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
@@ -1,0 +1,157 @@
+import { MapChip, MapChipFragment } from '../../src/MapChip'
+import { MapPaletteMatrix } from './../../src/MapData/MapPaletteMatrix'
+
+const c = [
+  new MapChip([new MapChipFragment(0, 0, 0)]),
+  new MapChip([new MapChipFragment(1, 0, 0)]),
+  new MapChip([new MapChipFragment(2, 0, 0)]),
+]
+
+describe('resize', () => {
+  it('Should matrix is expanded', () => {
+    const source = [
+      c[1], c[1], c[2], c[1], c[1],
+      c[1], c[2], c[2], c[2], c[1],
+      c[2], c[2], c[1], c[2], c[2],
+      c[1], c[2], c[2], c[2], c[1],
+      c[1], c[1], c[2], c[1], c[1]
+    ]
+    const matrix = new MapPaletteMatrix(5, 5, source)
+
+    matrix.resize(6, 7, null)
+
+    expect(matrix.width).toEqual(6)
+    expect(matrix.height).toEqual(7)
+    expect(matrix.size).toEqual(42)
+
+    expect(matrix.items).toEqual([
+      c[1], c[1], c[2], c[1], c[1], null,
+      c[1], c[2], c[2], c[2], c[1], null,
+      c[2], c[2], c[1], c[2], c[2], null,
+      c[1], c[2], c[2], c[2], c[1], null,
+      c[1], c[1], c[2], c[1], c[1], null,
+      null, null, null, null, null, null,
+      null, null, null, null, null, null,
+    ])
+  })
+
+  it('Should matrix is reduced', () => {
+    const source = [
+      c[1], c[1], c[2], c[1], c[1],
+      c[1], c[2], c[2], c[2], c[1],
+      c[2], c[2], c[1], c[2], c[2],
+      c[1], c[2], c[2], c[2], c[1],
+      c[1], c[1], c[2], c[1], c[1]
+    ]
+    const matrix = new MapPaletteMatrix(5, 5, source)
+
+    matrix.resize(3, 2, null)
+
+    expect(matrix.width).toEqual(3)
+    expect(matrix.height).toEqual(2)
+    expect(matrix.size).toEqual(6)
+
+    expect(matrix.items).toEqual([
+      c[1], c[1], c[2],
+      c[1], c[2], c[2]
+    ])
+  })
+})
+
+describe('#transferFromTiledMapData', () => {
+  it('Transfered a source data', () => {
+    const srcMatrix = new MapPaletteMatrix(5, 5)
+    const expectData = [
+      c[0], c[0], c[1], c[0], c[0],
+      c[0], c[1], c[1], c[1], c[0],
+      c[1], c[1], c[0], c[1], c[1],
+      c[0], c[1], c[1], c[1], c[0],
+      c[0], c[0], c[1], c[0], c[0]
+    ]
+
+    srcMatrix.set(expectData)
+
+    const destMatrix = new MapPaletteMatrix(5, 5)
+
+    destMatrix.transferFromTiledMapData(srcMatrix, 0, 0, 5, 5, 0, 0)
+
+    expect(destMatrix.items).toEqual(expectData)
+  })
+
+  it('With clipping', () => {
+    const source = [
+      c[1], c[1], c[2], c[1], c[1],
+      c[1], c[2], c[2], c[2], c[1],
+      c[2], c[2], c[1], c[2], c[2],
+      c[1], c[2], c[2], c[2], c[1],
+      c[1], c[1], c[2], c[1], c[1]
+    ]
+    const srcMatrix = new MapPaletteMatrix(5, 5, source)
+    const destMatrix = new MapPaletteMatrix(5, 5)
+
+    destMatrix.transferFromTiledMapData(srcMatrix, 1, 1, 3, 3, 2, 1)
+    expect(destMatrix.items).toEqual([
+      null, null, null, null, null,
+      null, null, c[2], c[2], c[2],
+      null, null, c[2], c[1], c[2],
+      null, null, c[2], c[2], c[2],
+      null, null, null, null, null,
+    ])
+
+    const destMatrix2 = new MapPaletteMatrix(5, 5)
+    destMatrix2.transferFromTiledMapData(srcMatrix, 1, 1, 3, 4, 3, 4)
+    expect(destMatrix2.items).toEqual([
+      null, null, null, null, null,
+      null, null, null, null, null,
+      null, null, null, null, null,
+      null, null, null, null, null,
+      null, null, null, c[2], c[2],
+    ])
+
+    const destMatrix3 = new MapPaletteMatrix(5, 5)
+    destMatrix3.transferFromTiledMapData(srcMatrix, 1, 1, 3, 3, -1, -1)
+    expect(destMatrix3.items).toEqual([
+      c[1], c[2], null, null, null,
+      c[2], c[2], null, null, null,
+      null, null, null, null, null,
+      null, null, null, null, null,
+      null, null, null, null, null,
+    ])
+  })
+})
+
+describe('#put', () => {
+  it('Put some MapChips', () => {
+    const data = new MapPaletteMatrix(3, 3)
+
+    data.put(c[1], 0, 0)
+    data.put(c[2], 1, 1)
+    data.put(c[1], 2, 2)
+    data.put(c[2], 0, 1)
+    data.put(c[1], 0, 2)
+    data.put(c[2], 2, 0)
+    data.put(c[1], 2, 1)
+    expect(data.items).toEqual([
+      c[1], null, c[2],
+      c[2], c[2], c[1],
+      c[1], null, c[1],
+    ])
+  })
+})
+
+describe('#getFromChipPosition', () => {
+  it('return a MapChip', () => {
+    const data = new MapPaletteMatrix(3, 3)
+    const source = [
+      c[1], c[0], c[2],
+      c[2], c[2], c[1],
+      c[1], c[0], c[1],
+    ]
+    data.set(source)
+
+    expect(data.getFromChipPosition(0, 0)).toEqual(c[1])
+    expect(data.getFromChipPosition(1, 0)).toEqual(c[0])
+    expect(data.getFromChipPosition(1, 1)).toEqual(c[2])
+    expect(data.getFromChipPosition(1, 2)).toEqual(c[0])
+  })
+})

--- a/packages/tiled-map/tests/TiledMapData.test.ts
+++ b/packages/tiled-map/tests/TiledMapData.test.ts
@@ -1,23 +1,60 @@
 import { TiledMapData } from './../src/MapData/TiledMapData'
 import { MapChip, MapChipFragment } from './../src/MapChip'
 
+const c1 = new MapChip([new MapChipFragment(0, 0, 0)])
+const c2 = new MapChip([new MapChipFragment(2, 0, 0)])
+const source = [
+  c1, null,   c2,
+  c2,   c2,   c1,
+  c1, null,   c1,
+]
+
 describe('#filter', () => {
   it('Return filtered map data', () => {
     const data = new TiledMapData(3, 3)
-    const c1 = new MapChip([new MapChipFragment(0, 0, 0)])
-    const c2 = new MapChip([new MapChipFragment(2, 0, 0)])
-    const source = [
-      c1, null,   c2,
-      c2,   c2,   c1,
-      c1, null,   c1,
-    ]
     data.set(source)
 
     const filtered = data.filter([c1])
     expect(filtered.items).toEqual([
-        c1, null, null,
+      c1, null, null,
       null, null,   c1,
-        c1, null,   c1,
+      c1, null,   c1,
     ])
+  })
+})
+
+describe('#toObject', () => {
+  it('Should return a serialized object', () => {
+    const data = new TiledMapData(3, 3)
+    data.set(source)
+
+    expect(data.toObject()).toEqual({
+      chipCountX: 3,
+      chipCountY: 3,
+      values: [
+        0, -1, 1,
+        1,  1, 0,
+        0, -1, 0
+      ],
+      palette: [c1.toObject(), c2.toObject()]
+    })
+  })
+})
+
+describe('#fromObject', () => {
+  it('Should return a deserialized value', () => {
+    const data = new TiledMapData(3, 3)
+    data.set(source)
+    const serialized = data.toObject()
+
+    const deserialized = TiledMapData.fromObject(serialized)
+    expect(deserialized.width).toEqual(3)
+    expect(deserialized.height).toEqual(3)
+    expect(deserialized.values.items).toEqual([
+      0, -1, 1,
+      1,  1, 0,
+      0, -1, 0
+    ])
+    expect(deserialized.palette).toEqual([c1, c2])
   })
 })


### PR DESCRIPTION
MapMatrixはMapChipを格納する行列ですが、内部のデータが冗長になりがちなので、パレットにMapChipを格納し、その配置を行列として持つことにします。