### PR TITLE
右クリック（マウスのサブボタン）で異なるColiderを配置できるようにする

### DIFF
--- a/packages/map-editor-components/src/ColisionMarkerComponent.ts
+++ b/packages/map-editor-components/src/ColisionMarkerComponent.ts
@@ -74,6 +74,17 @@ export class ColiderMarkerComponent extends LitElement {
     this._coliderCanvas.setColiderType(value)
   }
 
+  @property({type: Number})
+  get subColiderType() {
+    return this._coliderCanvas.selectedSubColiderType
+  }
+  set subColiderType(value: ColiderTypes) {
+    const oldValue = value
+    this.requestUpdate('subColiderType', oldValue);
+
+    this._coliderCanvas.setSubColiderType(value)
+  }
+
   private get width() {
     return this.xCount * this.gridWidth
   }
@@ -141,7 +152,7 @@ export class ColiderMarkerComponent extends LitElement {
 
   mouseDown(e: MouseEvent) {
     const mouseCursorPosition = this._cursorPositionCalculator.getMouseCursorPosition(e.pageX, e.pageY)
-    this._coliderCanvas.mouseDown(mouseCursorPosition.x, mouseCursorPosition.y)
+    this._coliderCanvas.mouseDown(mouseCursorPosition.x, mouseCursorPosition.y, e.button === 2)
 
     this._documentMouseMoveEventCallee = e => this.mouseMove(e)
     this._documentMouseUpEventCallee = e => this.mouseUp(e)

--- a/packages/map-editor-components/src/ColisionMarkerComponent.ts
+++ b/packages/map-editor-components/src/ColisionMarkerComponent.ts
@@ -23,6 +23,7 @@ export class ColiderMarkerComponent extends LitElement {
 
   @property({type: Number}) cursorChipX = 0
   @property({type: Number}) cursorChipY = 0
+  @property({type: Boolean}) preventDefaultContextMenu = true
 
   @property({type: String})
   get gridColor(): string {
@@ -216,6 +217,7 @@ export class ColiderMarkerComponent extends LitElement {
           class="grid-image grid"
           @mousedown="${(e: MouseEvent) => this.mouseDown(e)}"
           @mousemove="${(e: MouseEvent) => !this._coliderCanvas.isMouseDown ? this.mouseMove(e) : null}"
+          @contextmenu="${(e: MouseEvent) => this.preventDefaultContextMenu && e.preventDefault()}"
         ></div>
         <div class="cursor"></div>
       </div>

--- a/packages/map-editor-examples/simple_map_editor/index.css
+++ b/packages/map-editor-examples/simple_map_editor/index.css
@@ -17,4 +17,9 @@
 #coliderCanvas {
   position: absolute;
   top: 0;
+  user-select: none;
+}
+
+#mapCanvas {
+  user-select: none;
 }

--- a/packages/map-editor-examples/simple_map_editor/index.html
+++ b/packages/map-editor-examples/simple_map_editor/index.html
@@ -32,7 +32,6 @@
         <div class="map-editor">
           <map-canvas-component
             id="mapCanvas"
-            coliderType="colider"
             inactiveLayerOpacity="0.3"
             gridColor="#ccc"
             hiddenColider
@@ -41,6 +40,7 @@
             id="coliderCanvas"
             gridColor="#ccc"
             coliderType="1"
+            subColiderType="0"
           ></colider-marker-component>
         </div>
         <div class="chip-selector">

--- a/packages/map-editor-examples/simple_map_editor/src/simple_map_editor.ts
+++ b/packages/map-editor-examples/simple_map_editor/src/simple_map_editor.ts
@@ -97,8 +97,14 @@ async function initialize() {
   })
 
   // Set an active colider type
-  coliderTypeNoneRadioButton.addEventListener('change', () => coliderCanvas?.setAttribute('coliderType', '0'))
-  coliderTypeColiderRadioButton.addEventListener('change', () => coliderCanvas?.setAttribute('coliderType', '1'))
+  coliderTypeNoneRadioButton.addEventListener('change', () => {
+    coliderCanvas?.setAttribute('coliderType', '0')
+    coliderCanvas?.setAttribute('subColiderType', '1')
+  })
+  coliderTypeColiderRadioButton.addEventListener('change', () => {
+    coliderCanvas?.setAttribute('coliderType', '1')
+    coliderCanvas?.setAttribute('subColiderType', '0')
+  })
 
   autoTileSelector.addEventListener<any>('autotile-selected', (e: AutoTileSelectedEvent) => {
     // Set a AutoTileArrangement.

--- a/packages/map-editor/src/ColiderCanvas.ts
+++ b/packages/map-editor/src/ColiderCanvas.ts
@@ -101,6 +101,10 @@ export class ColiderCanvas implements EditorCanvas {
     this._setupBrush()
   }
 
+  setArrangement(value: Arrangement<ColiderTypes>) {
+    this._arrangement = value
+  }
+
   setBrushFromName(brushName: string) {
     const registeredBrush = Brushes.find(registeredBrush => registeredBrush.name === brushName)
 

--- a/packages/map-editor/src/ColiderCanvas.ts
+++ b/packages/map-editor/src/ColiderCanvas.ts
@@ -19,6 +19,7 @@ export class ColiderCanvas implements EditorCanvas {
   private _isMouseDown = false
   private _lastMapChipPosition = {x: -1, y: -1}
   private _selectedColiderType: ColiderTypes = 0
+  private _selectedSubColiderType: ColiderTypes = 0
 
   constructor() {
     this._brush = new Pen()
@@ -27,6 +28,10 @@ export class ColiderCanvas implements EditorCanvas {
 
   get selectedColiderType() {
     return this._selectedColiderType
+  }
+
+  get selectedSubColiderType() {
+    return this._selectedSubColiderType
   }
 
   get project() {
@@ -108,19 +113,24 @@ export class ColiderCanvas implements EditorCanvas {
 
   setColiderType(value: ColiderTypes) {
     this._selectedColiderType = value
-    this._setupBrush()
   }
 
-  private _setupBrush() {
+  setSubColiderType(value: ColiderTypes) {
+    this._selectedSubColiderType = value
+  }
+
+  private _setupBrush(isSubButton: boolean = false) {
     this._brush.setArrangement(this._arrangement)
 
     if (isColiderTypesRequired(this._arrangement)) {
-      this._arrangement.setColiderTypes(this._selectedColiderType)
+      this._arrangement.setColiderTypes(isSubButton ? this._selectedSubColiderType : this._selectedColiderType)
     }
   }
 
-  mouseDown(x: number, y: number) {
+  mouseDown(x: number, y: number, isSubButton: boolean = false) {
     this._isMouseDown = true
+
+    this._setupBrush(isSubButton)
 
     const chipPosition = this.convertFromCursorPositionToChipPosition(x, y)
     this._brush.mouseDown(chipPosition.x, chipPosition.y)

--- a/packages/map-editor/tests/ColiderCanvas.test.ts
+++ b/packages/map-editor/tests/ColiderCanvas.test.ts
@@ -5,6 +5,8 @@ import { ColiderRenderer } from './../src/ColiderRenderer'
 import { mocked } from 'ts-jest/utils'
 import { createMockedCanvas } from './TestHelpers/MockedCanvas'
 import { EmptyBrush } from './TestHelpers/EmptyBrush'
+import { ColiderTypes } from '@piyoppi/pico2map-tiled-colision-detector'
+import { ColiderArrangement } from './../src/Brushes/Arrangements/ColiderArrangement'
 
 jest.mock('./../src/ColiderRenderer')
 
@@ -74,21 +76,43 @@ describe('setCanvas', () => {
 })
 
 describe('#mouseDown', () => {
-  it('Should painted', () => {
+  function coliderCanvasFactory() {
     const project = Projects.add(tiledMap)
     const coliderCanvas = new ColiderCanvas()
     coliderCanvas.setCanvas(createMockedCanvas() as any, createMockedCanvas() as any)
     coliderCanvas.setProject(project)
 
     const brush = new EmptyBrush()
+    const arrangement = new ColiderArrangement()
+    arrangement.setColiderTypes = jest.fn()
     brush.mouseDown = jest.fn()
     brush.mouseMove = jest.fn().mockReturnValue([])
     coliderCanvas.setBrush(brush)
+    coliderCanvas.setArrangement(arrangement)
+
+    return { brush, coliderCanvas, arrangement }
+  }
+
+  it('Should painted', () => {
+    const { brush, coliderCanvas, arrangement } = coliderCanvasFactory()
+    coliderCanvas.setColiderType(1)
+    coliderCanvas.setSubColiderType(0)
 
     coliderCanvas.mouseDown(40, 70)
 
     expect(coliderCanvas.isMouseDown).toEqual(true)
     expect(brush.mouseDown).toBeCalledWith(1, 2)
     expect(brush.mouseMove).toBeCalledWith(1, 2)
+    expect(arrangement.setColiderTypes).toHaveBeenCalledWith(1)
+  })
+
+  it('Should set subColiderType when subButton is true', () => {
+    const { coliderCanvas, arrangement } = coliderCanvasFactory()
+
+    coliderCanvas.setColiderType(1)
+    coliderCanvas.setSubColiderType(0)
+    coliderCanvas.mouseDown(40, 70, true)
+
+    expect(arrangement.setColiderTypes).toHaveBeenCalledWith(0)
   })
 })


### PR DESCRIPTION
右クリック（マウスのサブボタン）押下時に適用するColiderTypeを設定するAttribute「subColiderType」を追加し、メインで選択されているColiderとは異なるColiderを配置できるようにします。