### PR TITLE
マップチップが選択されていないときは配置処理をしない

### DIFF
--- a/packages/map-editor/src/MapCanvas.ts
+++ b/packages/map-editor/src/MapCanvas.ts
@@ -183,9 +183,11 @@ export class MapCanvas implements EditorCanvas {
       return
     }
 
+    if (isMapChipFragmentRequired(this._arrangement) && this._selectedMapChipFragments.length < 1) return
+
     this._isMouseDown = true
 
-    if (isMapChipFragmentRequired(this._arrangement) && this._selectedMapChipFragments) {
+    if (isMapChipFragmentRequired(this._arrangement)) {
       this._arrangement.setMapChips(this._selectedMapChipFragments)
     }
 

--- a/packages/map-editor/tests/MapCanvas.test.ts
+++ b/packages/map-editor/tests/MapCanvas.test.ts
@@ -203,12 +203,22 @@ describe('#mouseDown', () => {
 
   it('Should painted', () => {
     const {mapCanvas, brush} = mapCanvasFactory()
+    mapCanvas.setMapChipFragments(c1Fragments)
 
     mapCanvas.mouseDown(40, 70)
 
     expect(mapCanvas.isMouseDown).toEqual(true)
     expect(brush.mouseDown).toBeCalledWith(1, 2)
     expect(brush.mouseMove).toBeCalledWith(1, 2)
+  })
+
+  it('Should not painted when the arrangement requires mapChipFragments and the mapCanavs has no mapChipFragments', () => {
+    const {mapCanvas, brush} = mapCanvasFactory()
+
+    mapCanvas.mouseDown(40, 70)
+    expect(mapCanvas.isMouseDown).toEqual(false)
+    expect(brush.mouseDown).not.toBeCalled()
+    expect(brush.mouseMove).not.toBeCalled()
   })
 
   it('Should picked a mapchip when the cursor is over the mapchip', () => {

--- a/packages/map-editor/tests/TestHelpers/EmptyArrangement.ts
+++ b/packages/map-editor/tests/TestHelpers/EmptyArrangement.ts
@@ -5,4 +5,3 @@ export class EmptyArrangement<T> implements Arrangement<T> {
   setMapChips(_: Array<T>) {}
   apply(_: Array<BrushPaint>): Array<ArrangementPaint<T>> { return [] }
 }
-


### PR DESCRIPTION
Arrangementがマップチップを要求する場合、マップチップが選択されていないときに配置処理をすると、Arrangementから例外がスローされる場合があります。MapCanvas側でマップチップが選択されていないときは配置処理しない処理を追加します。