### PR TITLE
特定のマップチップ画像を持つマップチップをマップデータから削除できるようにする

### DIFF
--- a/packages/tiled-map/src/MapData/TiledMapData.ts
+++ b/packages/tiled-map/src/MapData/TiledMapData.ts
@@ -36,12 +36,6 @@ export class TiledMapData extends MapPaletteMatrix<TiledMapDataItem> {
     }) as Array<MapChip>
   }
 
-  removeMapChipsFromImage(image: MapChipImage) {
-    const mapChips = this.getMapChipsFromImage(image)
-
-    mapChips.forEach(mapChip => this.removeMapChip(mapChip))
-  }
-
   remove(mapChip: MapChip): boolean {
     const removePaletteId = this.palette.findIndex(item => item?.identifyKey === mapChip.identifyKey)
     if (removePaletteId < 0) return false

--- a/packages/tiled-map/src/MapData/TiledMapData.ts
+++ b/packages/tiled-map/src/MapData/TiledMapData.ts
@@ -21,7 +21,7 @@ export class TiledMapData extends MapPaletteMatrix<TiledMapDataItem> {
     )
   }
 
-  getMapChipsFromImage(image: MapChipImage) {
+  findByImage(image: MapChipImage) {
     const registeredChips = new Set()
     return this.items.filter(chip => {
       if (!chip) return false
@@ -42,7 +42,7 @@ export class TiledMapData extends MapPaletteMatrix<TiledMapDataItem> {
     mapChips.forEach(mapChip => this.removeMapChip(mapChip))
   }
 
-  removeMapChip(mapChip: MapChip): boolean {
+  remove(mapChip: MapChip): boolean {
     const removePaletteId = this.palette.findIndex(item => item?.identifyKey === mapChip.identifyKey)
     if (removePaletteId < 0) return false
 

--- a/packages/tiled-map/src/MapData/TiledMapData.ts
+++ b/packages/tiled-map/src/MapData/TiledMapData.ts
@@ -1,4 +1,5 @@
-import { MapChip, MapChipProperties,  AutoTileMapChipProperties, isAutoTileMapChipProperties, AutoTileMapChip } from './../MapChip'
+import { MapChip, MapChipProperties, AutoTileMapChipProperties, isAutoTileMapChipProperties, AutoTileMapChip } from './../MapChip'
+import { MapChipImage } from '../MapChipImage'
 import { MapPaletteMatrix } from './MapPaletteMatrix'
 
 export type TiledMapDataItem = MapChip | null
@@ -20,6 +21,27 @@ export class TiledMapData extends MapPaletteMatrix<TiledMapDataItem> {
     )
   }
 
+  getMapChipsFromImage(image: MapChipImage) {
+    const registeredChips = new Set()
+    return this.items.filter(chip => {
+      if (!chip) return false
+
+      const found = chip.items.find(fragment => fragment.chipId === image.id) && !registeredChips.has(chip.identifyKey)
+
+      if (found) {
+        registeredChips.add(chip.identifyKey)
+      }
+
+      return found
+    }) as Array<MapChip>
+  }
+
+  removeMapChipsFromImage(image: MapChipImage) {
+    const mapChips = this.getMapChipsFromImage(image)
+
+    mapChips.forEach(mapChip => this.removeMapChip(mapChip))
+  }
+
   removeMapChip(mapChip: MapChip): boolean {
     const removePaletteId = this.palette.findIndex(item => item?.identifyKey === mapChip.identifyKey)
     if (removePaletteId < 0) return false
@@ -27,6 +49,7 @@ export class TiledMapData extends MapPaletteMatrix<TiledMapDataItem> {
     this.palette.splice(removePaletteId, 1)
     this.values.items.forEach((paletteIndex, valueIndex) => {
       if (paletteIndex === removePaletteId) this.values.items[valueIndex] = -1
+      if (paletteIndex > removePaletteId) this.values.items[valueIndex] = this.values.items[valueIndex] - 1
     })
 
     return true

--- a/packages/tiled-map/tests/TiledMapData.test.ts
+++ b/packages/tiled-map/tests/TiledMapData.test.ts
@@ -1,8 +1,14 @@
 import { TiledMapData } from './../src/MapData/TiledMapData'
 import { MapChip, MapChipFragment } from './../src/MapChip'
+import { MapChipImage } from '../src/MapChipImage'
 
-const c1 = new MapChip([new MapChipFragment(0, 0, 0)])
-const c2 = new MapChip([new MapChipFragment(2, 0, 0)])
+const image1 = new MapChipImage('dummy1.png', 1)
+const image2 = new MapChipImage('dummy2.png', 2)
+const image3 = new MapChipImage('dummy3.png', 3)
+const c1 = new MapChip([new MapChipFragment(0, 0, image1.id)])
+const c2 = new MapChip([new MapChipFragment(1, 0, image2.id)])
+const c3 = new MapChip([new MapChipFragment(2, 0, image1.id)])
+const c4 = new MapChip([new MapChipFragment(3, 0, image2.id)])
 const source = [
   c1, null,   c2,
   c2,   c2,   c1,
@@ -62,14 +68,53 @@ describe('#fromObject', () => {
 describe('#removeMapChip', () => {
   it('Should remove mapChip from palette and values', () => {
     const data = new TiledMapData(3, 3)
-    data.set(source)
+    data.set([
+      c1, null,   c2,
+      c2,   c2,   c1,
+      c1, null,   c3,
+    ])
 
     data.removeMapChip(c1)
-    expect(data.palette).toEqual([c2])
+    expect(data.palette).toEqual([c2, c3])
     expect(data.values.items).toEqual([
-      -1, -1,  1,
-       1,  1, -1,
-      -1, -1, -1
+      -1, -1,  0,
+       0,  0, -1,
+      -1, -1,  1
+    ])
+  })
+})
+
+describe('getMapChipsFromImage', () => {
+  it('Should return mapChips with a specific image', () => {
+    const data = new TiledMapData(3, 3)
+    data.set([
+      c1, null,   c2,
+      c2,   c2,   c1,
+      c1, null,   c3,
+    ])
+
+    expect(data.getMapChipsFromImage(image1)).toEqual([c1, c3])
+    expect(data.getMapChipsFromImage(image2)).toEqual([c2])
+    expect(data.getMapChipsFromImage(image3)).toEqual([])
+  })
+})
+
+describe('removeMapChipsFromImage', () => {
+  it('Should remove mapChips with a specific image', () => {
+    const data = new TiledMapData(3, 3)
+    data.set([
+      c1, null,   c2,
+      c2,   c2,   c1,
+      c1,   c4,   c3,
+    ])
+
+    data.removeMapChipsFromImage(image1)
+
+    expect(data.palette).toEqual([c2, c4])
+    expect(data.values.items).toEqual([
+      -1, -1,  0,
+       0,  0, -1,
+      -1,  1, -1
     ])
   })
 })

--- a/packages/tiled-map/tests/TiledMapData.test.ts
+++ b/packages/tiled-map/tests/TiledMapData.test.ts
@@ -65,7 +65,7 @@ describe('#fromObject', () => {
   })
 })
 
-describe('#removeMapChip', () => {
+describe('#remove', () => {
   it('Should remove mapChip from palette and values', () => {
     const data = new TiledMapData(3, 3)
     data.set([
@@ -74,7 +74,7 @@ describe('#removeMapChip', () => {
       c1, null,   c3,
     ])
 
-    data.removeMapChip(c1)
+    data.remove(c1)
     expect(data.palette).toEqual([c2, c3])
     expect(data.values.items).toEqual([
       -1, -1,  0,
@@ -84,7 +84,7 @@ describe('#removeMapChip', () => {
   })
 })
 
-describe('getMapChipsFromImage', () => {
+describe('findByImage', () => {
   it('Should return mapChips with a specific image', () => {
     const data = new TiledMapData(3, 3)
     data.set([
@@ -93,9 +93,9 @@ describe('getMapChipsFromImage', () => {
       c1, null,   c3,
     ])
 
-    expect(data.getMapChipsFromImage(image1)).toEqual([c1, c3])
-    expect(data.getMapChipsFromImage(image2)).toEqual([c2])
-    expect(data.getMapChipsFromImage(image3)).toEqual([])
+    expect(data.findByImage(image1)).toEqual([c1, c3])
+    expect(data.findByImage(image2)).toEqual([c2])
+    expect(data.findByImage(image3)).toEqual([])
   })
 })
 

--- a/packages/tiled-map/tests/TiledMapData.test.ts
+++ b/packages/tiled-map/tests/TiledMapData.test.ts
@@ -8,7 +8,6 @@ const image3 = new MapChipImage('dummy3.png', 3)
 const c1 = new MapChip([new MapChipFragment(0, 0, image1.id)])
 const c2 = new MapChip([new MapChipFragment(1, 0, image2.id)])
 const c3 = new MapChip([new MapChipFragment(2, 0, image1.id)])
-const c4 = new MapChip([new MapChipFragment(3, 0, image2.id)])
 const source = [
   c1, null,   c2,
   c2,   c2,   c1,
@@ -96,25 +95,5 @@ describe('findByImage', () => {
     expect(data.findByImage(image1)).toEqual([c1, c3])
     expect(data.findByImage(image2)).toEqual([c2])
     expect(data.findByImage(image3)).toEqual([])
-  })
-})
-
-describe('removeMapChipsFromImage', () => {
-  it('Should remove mapChips with a specific image', () => {
-    const data = new TiledMapData(3, 3)
-    data.set([
-      c1, null,   c2,
-      c2,   c2,   c1,
-      c1,   c4,   c3,
-    ])
-
-    data.removeMapChipsFromImage(image1)
-
-    expect(data.palette).toEqual([c2, c4])
-    expect(data.values.items).toEqual([
-      -1, -1,  0,
-       0,  0, -1,
-      -1,  1, -1
-    ])
   })
 })


### PR DESCRIPTION
マップチップ画像を削除したときに、マップデータから対応するデータを消す必要があるので、これをできるようにします。