### PR TITLE
TiledMapData.removeしたマップチップを配置できない

### DIFF
--- a/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
+++ b/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
@@ -97,6 +97,22 @@ export class MapPaletteMatrix<T> {
     this.set(items)
   }
 
+  remove(target: MapPaletteMatrixItem<T>): boolean {
+    if (!target) return false
+
+    const removePaletteId = this.palette.findIndex(item => item?.identifyKey === target.identifyKey)
+    if (removePaletteId < 0) return false
+
+    this.palette.splice(removePaletteId, 1)
+    this.values.items.forEach((paletteIndex, valueIndex) => {
+      if (paletteIndex === removePaletteId) this.values.items[valueIndex] = -1
+      if (paletteIndex > removePaletteId) this.values.items[valueIndex] = this.values.items[valueIndex] - 1
+    })
+    this._paletteIndexes.delete(target.identifyKey)
+
+    return true
+  }
+
   private _getPaletteIndexFromValue(value: MapPaletteMatrixItem<T>): number {
     if (value === null) return -1
 

--- a/packages/tiled-map/src/MapData/TiledMapData.ts
+++ b/packages/tiled-map/src/MapData/TiledMapData.ts
@@ -36,19 +36,6 @@ export class TiledMapData extends MapPaletteMatrix<TiledMapDataItem> {
     }) as Array<MapChip>
   }
 
-  remove(mapChip: MapChip): boolean {
-    const removePaletteId = this.palette.findIndex(item => item?.identifyKey === mapChip.identifyKey)
-    if (removePaletteId < 0) return false
-
-    this.palette.splice(removePaletteId, 1)
-    this.values.items.forEach((paletteIndex, valueIndex) => {
-      if (paletteIndex === removePaletteId) this.values.items[valueIndex] = -1
-      if (paletteIndex > removePaletteId) this.values.items[valueIndex] = this.values.items[valueIndex] - 1
-    })
-
-    return true
-  }
-
   toObject(): TiledMapDataProperties {
     return {
       chipCountX: this.width,

--- a/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
+++ b/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
@@ -276,3 +276,41 @@ describe('#rebuild', () => {
     expect(data.palette).toEqual([c[1], c[2], c[4]])
   })
 })
+
+describe('#remove', () => {
+  it('Should remove mapChip from palette and values', () => {
+    const data = new MapPaletteMatrix(3, 3)
+    data.set([
+      c[1], null, c[2],
+      c[2], c[2], c[1],
+      c[1], null, c[3],
+    ])
+
+    data.remove(c[1])
+    expect(data.palette).toEqual([c[2], c[3]])
+    expect(data.values.items).toEqual([
+      -1, -1,  0,
+       0,  0, -1,
+      -1, -1,  1
+    ])
+  })
+
+  it('Should be able to put items in the removed area', () => {
+    const data = new MapPaletteMatrix(3, 3)
+    data.set([
+      c[1], null, c[2],
+      c[2], c[2], c[1],
+      c[1], null, c[3],
+    ])
+
+    data.remove(c[1])
+
+    data.put(c[1], 0, 0)
+    expect(data.palette).toEqual([c[2], c[3], c[1]])
+    expect(data.values.items).toEqual([
+       2, -1,  0,
+       0,  0, -1,
+      -1, -1,  1
+    ])
+  })
+})

--- a/packages/tiled-map/tests/TiledMapData.test.ts
+++ b/packages/tiled-map/tests/TiledMapData.test.ts
@@ -64,25 +64,6 @@ describe('#fromObject', () => {
   })
 })
 
-describe('#remove', () => {
-  it('Should remove mapChip from palette and values', () => {
-    const data = new TiledMapData(3, 3)
-    data.set([
-      c1, null,   c2,
-      c2,   c2,   c1,
-      c1, null,   c3,
-    ])
-
-    data.remove(c1)
-    expect(data.palette).toEqual([c2, c3])
-    expect(data.values.items).toEqual([
-      -1, -1,  0,
-       0,  0, -1,
-      -1, -1,  1
-    ])
-  })
-})
-
 describe('findByImage', () => {
   it('Should return mapChips with a specific image', () => {
     const data = new TiledMapData(3, 3)


### PR DESCRIPTION
パレットインデックスをクリアしていないので、パレットとの整合性が合わなくなって配置できなくなってしまっていた