### PR TITLE
マップチップの矩形選択が正しく行われない不具合を修正

### DIFF
--- a/packages/map-editor/src/MapChipSelector.ts
+++ b/packages/map-editor/src/MapChipSelector.ts
@@ -62,7 +62,10 @@ export class MapChipSelector {
   private _selectAtMouseCursor() {
     this.clear()
 
-    const chipPosition = this._startChipPosition
+    const chipPosition = {
+      x: Math.min(this._startChipPosition.x, this._endChipPosition.x),
+      y: Math.min(this._startChipPosition.y, this._endChipPosition.y)
+    }
     const maximumChipCount = this._chipImage.getChipCount(this._tiledMap.chipWidth, this._tiledMap.chipHeight)
     const {width, height} = this.selectedChipSize
 

--- a/packages/map-editor/tests/MapChipSelector.test.ts
+++ b/packages/map-editor/tests/MapChipSelector.test.ts
@@ -83,6 +83,14 @@ describe('#mouseUp', () => {
       new MapChipFragment(1, 2, chipImage.id),
       new MapChipFragment(2, 2, chipImage.id)
     ])
+
+    selector.mouseDown(80, 80)
+    selector.mouseUp(40, 80)
+
+    expect(selector.selectedChips).toEqual([
+      new MapChipFragment(1, 2, chipImage.id),
+      new MapChipFragment(2, 2, chipImage.id)
+    ])
   })
 
   it('Should set selectedChips when the cursor x-position is outside of image', () => {


### PR DESCRIPTION
矩形の設定方法によっては正しく矩形選択が行われないので修正します