### PR TITLE
編集するレイヤーを変更したときにAutoTileが正しく配置されない

### DIFF
--- a/packages/map-editor/src/MapCanvas.ts
+++ b/packages/map-editor/src/MapCanvas.ts
@@ -161,6 +161,8 @@ export class MapCanvas implements EditorCanvas {
     }
 
     this._activeLayerIndex = index
+
+    this._setupBrush()
   }
 
   setMapChipPickerEnabled(value: boolean) {

--- a/packages/map-editor/tests/MapCanvas.test.ts
+++ b/packages/map-editor/tests/MapCanvas.test.ts
@@ -28,15 +28,27 @@ describe('#setActiveLayer', () => {
     const tiledMap = new TiledMap(30, 30, 32, 32)
     const project = Projects.add(tiledMap)
     const mapCanvas = new MapCanvas()
+
+    const brush = new EmptyBrush()
+    const arrangement = new DummyAutoTileArrangement()
+    brush.setArrangement = jest.fn()
+    arrangement.setTiledMapData = jest.fn()
+    mapCanvas.setBrush(brush)
+    mapCanvas.setArrangement(arrangement)
+
     mapCanvas.setProject(project)
     
     tiledMap.addLayer()
 
     mapCanvas.setActiveLayer(1)
+
     expect(mapCanvas.activeLayer).toEqual(1)
 
     // Layer 2 is out of range.
     expect(() => mapCanvas.setActiveLayer(2)).toThrow()
+
+    expect(brush.setArrangement).toBeCalled()
+    expect(arrangement.setTiledMapData).toBeCalled()
   })
 })
 

--- a/packages/map-editor/tests/MapCanvas.test.ts
+++ b/packages/map-editor/tests/MapCanvas.test.ts
@@ -115,7 +115,6 @@ describe('#setCanvases', () => {
   })
 
   it('Should not call rendering function when projectId is not given.', async () => {
-    const tiledMap = new TiledMap(30, 30, 32, 32)
     const mapCanvas = new MapCanvas()
     mapCanvas.renderAll = jest.fn()
 

--- a/packages/map-editor/tests/TestHelpers/DummyAutoTileArrangement.ts
+++ b/packages/map-editor/tests/TestHelpers/DummyAutoTileArrangement.ts
@@ -1,9 +1,10 @@
 import { Arrangement, ArrangementPaint } from '../../src/Brushes/Arrangements/Arrangement'
 import { BrushPaint } from './../../src/Brushes/Brush'
-import { AutoTile } from '@piyoppi/pico2map-tiled'
+import { AutoTile, TiledMapData, TiledMapDataItem } from '@piyoppi/pico2map-tiled'
 
-export class DummyAutoTileArrangement<T> implements Arrangement<T> {
-  setMapChips(_: Array<T>) {}
+export class DummyAutoTileArrangement implements Arrangement<TiledMapDataItem> {
+  setMapChips(_: Array<TiledMapDataItem>) {}
   setAutoTile(_: AutoTile) {}
-  apply(_: Array<BrushPaint>): Array<ArrangementPaint<T>> { return [] }
+  setTiledMapData(_: TiledMapData) {}
+  apply(_: Array<BrushPaint>): Array<ArrangementPaint<TiledMapDataItem>> { return [] }
 }


### PR DESCRIPTION
MapCanvasでアクティブなレイヤーが変更されたときはArrangement/Brushを初期化しないと、AutoTileArrangementで参照されるマップデータが更新されないので、編集レイヤーとは異なるレイヤーを参照して割り当てチップを決定してしまう。