### PR TITLE
MapPaletteMatrix.removeを呼び出すと内部のパレットインデックス辞書が壊れる

### DIFF
--- a/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
+++ b/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
@@ -54,8 +54,8 @@ export class MapPaletteMatrix<T> {
   setValuePalette(values: Array<number>, palette: Array<MapPaletteMatrixItem<T>>) {
     if (values.length !== this._values.items.length) throw new Error()
 
-    this._values.set(values)
-    this._palette = palette
+    this._values.set([...values])
+    this._palette = [...palette]
 
     this._paletteIndexes.clear()
     this._palette.forEach((paletteItem, index) => {

--- a/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
+++ b/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
@@ -58,11 +58,17 @@ export class MapPaletteMatrix<T> {
     this._palette = [...palette]
 
     this._paletteIndexes.clear()
-    this._palette.forEach((paletteItem, index) => {
-      if (!paletteItem) return
+
+    for (const [index, paletteItem] of this._palette.entries()) {
+      if (!paletteItem) continue
+
+      if (this._paletteIndexes.has(paletteItem.identifyKey)) {
+        this.rebuild()
+        break
+      }
 
       this._paletteIndexes.set(paletteItem.identifyKey, index)
-    })
+    }
   }
 
   transferFromTiledMapData(src: MapPaletteMatrix<T>, srcX: number, srcY: number, width: number, height: number, destX: number, destY: number) {

--- a/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
+++ b/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
@@ -56,6 +56,13 @@ export class MapPaletteMatrix<T> {
 
     this._values.set(values)
     this._palette = palette
+
+    this._paletteIndexes.clear()
+    this._palette.forEach((paletteItem, index) => {
+      if (!paletteItem) return
+
+      this._paletteIndexes.set(paletteItem.identifyKey, index)
+    })
   }
 
   transferFromTiledMapData(src: MapPaletteMatrix<T>, srcX: number, srcY: number, width: number, height: number, destX: number, destY: number) {

--- a/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
+++ b/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
@@ -104,10 +104,16 @@ export class MapPaletteMatrix<T> {
     if (removePaletteId < 0) return false
 
     this.palette.splice(removePaletteId, 1)
+
     this.values.items.forEach((paletteIndex, valueIndex) => {
       if (paletteIndex === removePaletteId) this.values.items[valueIndex] = -1
       if (paletteIndex > removePaletteId) this.values.items[valueIndex] = this.values.items[valueIndex] - 1
     })
+
+    for (const [k, v] of this._paletteIndexes.entries()) {
+      if (v > removePaletteId) this._paletteIndexes.set(k, v - 1)
+    }
+
     this._paletteIndexes.delete(target.identifyKey)
 
     return true

--- a/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
+++ b/packages/tiled-map/src/MapData/MapPaletteMatrix.ts
@@ -48,7 +48,7 @@ export class MapPaletteMatrix<T> {
   set(items: Array<MapPaletteMatrixItem<T>>) {
     if (items.length !== this._values.items.length) throw new Error()
 
-    this._values.set(items.map(value => this._getPaletteIndexFromValue(value)))
+    this._values.set(items.map(value => this._getOrGeneratePaletteIndex(value)))
   }
 
   setValuePalette(values: Array<number>, palette: Array<MapPaletteMatrixItem<T>>) {
@@ -64,13 +64,13 @@ export class MapPaletteMatrix<T> {
       src.width, src.height, this.width, this.height,
       (pickupX, pickupY, putX, putY) => {
         const item = src.getFromChipPosition(pickupX, pickupY)
-        this._values.put(this._getPaletteIndexFromValue(item), putX, putY)
+        this._values.put(this._getOrGeneratePaletteIndex(item), putX, putY)
       }
     )
   }
 
   resize(chipCountX: number, chipCountY: number, emptyValue: MapPaletteMatrixItem<T>) {
-    this._values.resize(chipCountX, chipCountY, this._getPaletteIndexFromValue(emptyValue))
+    this._values.resize(chipCountX, chipCountY, this._getOrGeneratePaletteIndex(emptyValue))
   }
 
   getFromChipPosition(x: number, y: number): MapPaletteMatrixItem<T> {
@@ -80,7 +80,7 @@ export class MapPaletteMatrix<T> {
   }
 
   put(item: MapPaletteMatrixItem<T>, x: number, y: number) {
-    this._values.put(this._getPaletteIndexFromValue(item), x, y)
+    this._values.put(this._getOrGeneratePaletteIndex(item), x, y)
   }
 
   clone() {
@@ -113,10 +113,16 @@ export class MapPaletteMatrix<T> {
     return true
   }
 
-  private _getPaletteIndexFromValue(value: MapPaletteMatrixItem<T>): number {
+  getPaletteIndex(value: MapPaletteMatrixItem<T>) {
     if (value === null) return -1
 
-    const index = this._paletteIndexes.get(value.identifyKey)
+    return this._paletteIndexes.get(value.identifyKey)
+  }
+
+  private _getOrGeneratePaletteIndex(value: MapPaletteMatrixItem<T>): number {
+    if (value === null) return -1
+
+    const index = this.getPaletteIndex(value)
     if (index !== undefined) return index
 
     this._palette.push(value)

--- a/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
+++ b/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
@@ -299,15 +299,17 @@ describe('#remove', () => {
     const data = new MapPaletteMatrix(3, 3)
     data.set([
       c[1], null, c[2],
-      c[2], c[2], c[1],
-      c[1], null, c[3],
+      c[2], c[4], c[1],
+      c[0], null, c[3],
     ])
 
-    data.remove(c[2])
-    expect(data.palette).toEqual([c[1], c[3]])
+    data.remove(c[4])
+    expect(data.palette).toEqual([c[1], c[2], c[0], c[3]])
+    expect(data.getPaletteIndex(c[0])).toEqual(2)
     expect(data.getPaletteIndex(c[1])).toEqual(0)
-    expect(data.getPaletteIndex(c[2])).toEqual(undefined)
-    expect(data.getPaletteIndex(c[3])).toEqual(1)
+    expect(data.getPaletteIndex(c[2])).toEqual(1)
+    expect(data.getPaletteIndex(c[3])).toEqual(3)
+    expect(data.getPaletteIndex(c[4])).toEqual(undefined)
   })
 
   it('Should be able to put items in the removed area', () => {

--- a/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
+++ b/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
@@ -295,6 +295,21 @@ describe('#remove', () => {
     ])
   })
 
+  it('Should rebuild the palette index', () => {
+    const data = new MapPaletteMatrix(3, 3)
+    data.set([
+      c[1], null, c[2],
+      c[2], c[2], c[1],
+      c[1], null, c[3],
+    ])
+
+    data.remove(c[2])
+    expect(data.palette).toEqual([c[1], c[3]])
+    expect(data.getPaletteIndex(c[1])).toEqual(0)
+    expect(data.getPaletteIndex(c[2])).toEqual(undefined)
+    expect(data.getPaletteIndex(c[3])).toEqual(1)
+  })
+
   it('Should be able to put items in the removed area', () => {
     const data = new MapPaletteMatrix(3, 3)
     data.set([

--- a/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
+++ b/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
@@ -168,11 +168,23 @@ describe('#clone', () => {
     const data = new MapPaletteMatrix(3, 3, source)
 
     const cloned = data.clone()
-    expect(data).not.toEqual(cloned)
     expect(data.width).toEqual(cloned.width)
     expect(data.height).toEqual(cloned.height)
     expect(data.values.items).toEqual(cloned.values.items)
     expect(data.palette).toEqual(cloned.palette)
+  })
+
+  it('Should not be changed some properties when the property of cloned item is changed', () => {
+    const source = [
+      c[1], c[0], c[2],
+      c[2], c[2], c[1],
+      c[1], null, c[1],
+    ]
+    const data = new MapPaletteMatrix(3, 3, source)
+
+    const cloned = data.clone()
+    data.put(c[1], 1, 2)
+    expect(data).not.toEqual(cloned)
   })
 })
 

--- a/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
+++ b/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
@@ -194,6 +194,9 @@ describe('#setValuePalette', () => {
       0, -1, 0
     ])
     expect(data.palette).toEqual([c[1], c[0], c[2]])
+    expect(data.getPaletteIndex(c[0])).toEqual(1)
+    expect(data.getPaletteIndex(c[1])).toEqual(0)
+    expect(data.getPaletteIndex(c[2])).toEqual(2)
   })
 })
 

--- a/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
+++ b/packages/tiled-map/tests/MapData/MapPaletteMatrix.test.ts
@@ -209,6 +209,38 @@ describe('#setValuePalette', () => {
     expect(data.getPaletteIndex(c[0])).toEqual(1)
     expect(data.getPaletteIndex(c[1])).toEqual(0)
     expect(data.getPaletteIndex(c[2])).toEqual(2)
+    expect(data.items).toEqual([
+      c[1], c[0], c[2],
+      c[2], c[2], c[1],
+      c[1], null, c[1],
+    ])
+  })
+
+  it('Should set values and the palette when the palette has duplicate items', () => {
+    const data = new MapPaletteMatrix(3, 3)
+    data.setValuePalette(
+      [
+        1,  0, 2,
+        3,  2, 0,
+        0, -1, 0
+      ],
+      [c[1], c[2], c[0], c[2]]
+    )
+
+    expect(data.values.items).toEqual([
+        0,  1, 2,
+        0,  2, 1,
+        1, -1, 1
+    ])
+    expect(data.palette).toEqual([c[2], c[1], c[0]])
+    expect(data.getPaletteIndex(c[0])).toEqual(2)
+    expect(data.getPaletteIndex(c[1])).toEqual(1)
+    expect(data.getPaletteIndex(c[2])).toEqual(0)
+    expect(data.items).toEqual([
+      c[2], c[1], c[0],
+      c[2], c[0], c[1],
+      c[1], null, c[1],
+    ])
   })
 })
 


### PR DESCRIPTION
アイテムのIdentifyKeyからパレットインデックスを引くための辞書 `_paletteIndexes` が存在しますが、MapPaletteMatrix.removeを呼び出すときにこれを更新しないので壊れてしまう不具合を修正します。