### PR TITLE
オートタイルのIDが衝突してしまう問題の修正

### DIFF
--- a/packages/tiled-map/src/AutoTile/AutoTiles.ts
+++ b/packages/tiled-map/src/AutoTile/AutoTiles.ts
@@ -16,6 +16,7 @@ export class AutoTiles {
 
   push(item: AutoTile) {
     this._autoTiles.set(item.id, item)
+    this._maxId = Math.max(this._maxId, item.id)
   }
 
   remove(item: AutoTile) {

--- a/packages/tiled-map/src/AutoTile/AutoTiles.ts
+++ b/packages/tiled-map/src/AutoTile/AutoTiles.ts
@@ -64,7 +64,9 @@ export class AutoTiles {
     this._autoTiles.clear()
 
     val.autoTiles.forEach(objectedAutoTile => {
-      this.push(AutoTile.fromObject(objectedAutoTile))
+      const autoTile = AutoTile.fromObject(objectedAutoTile)
+      this.push(autoTile)
+      this._maxId = Math.max(this._maxId, autoTile.id)
     })
   }
 }

--- a/packages/tiled-map/tests/AutoTile/AutoTiles.test.ts
+++ b/packages/tiled-map/tests/AutoTile/AutoTiles.test.ts
@@ -84,4 +84,19 @@ describe('import', () => {
     const imported2 = autoTiles.import(strategy)
     expect(imported2[0].id).toEqual(2)
   })
+
+  it('A unique id should be assigned to AutoTile', () => {
+    const strategy = new DummyAutoTileImportStrategy(mapChipImage1)
+    const autoTiles = new AutoTiles()
+
+    autoTiles.fromObject({
+      autoTiles: [
+        autoTile1.toObject(),
+        autoTile3.toObject(),
+      ]
+    })
+
+    const imported = autoTiles.import(strategy)
+    expect(imported[0].id).toEqual(4)
+  })
 })

--- a/packages/tiled-map/tests/AutoTile/AutoTiles.test.ts
+++ b/packages/tiled-map/tests/AutoTile/AutoTiles.test.ts
@@ -86,7 +86,6 @@ describe('import', () => {
   })
 
   it('A unique id should be assigned to AutoTile', () => {
-    const strategy = new DummyAutoTileImportStrategy(mapChipImage1)
     const autoTiles = new AutoTiles()
 
     autoTiles.fromObject({
@@ -96,7 +95,12 @@ describe('import', () => {
       ]
     })
 
-    const imported = autoTiles.import(strategy)
-    expect(imported[0].id).toEqual(4)
+    const imported1 = autoTiles.import(new DummyAutoTileImportStrategy(mapChipImage1))
+    expect(imported1[0].id).toEqual(4)
+
+    autoTiles.push(new AutoTile([c2], 5))
+
+    const imported2 = autoTiles.import(new DummyAutoTileImportStrategy(mapChipImage2))
+    expect(imported2[0].id).toEqual(6)
   })
 })


### PR DESCRIPTION
AutoTiles.fromObject で読み込んだ後にAutoTiles.importを呼び出すとオートタイルのIDが衝突してしまうので修正します