### PR TITLE
DefaultAutoTileImportStrategyで範囲外の画像を読み込む不具合を修正する

### DIFF
--- a/packages/tiled-map/src/AutoTile/DefaultAutoTileImportStrategy.ts
+++ b/packages/tiled-map/src/AutoTile/DefaultAutoTileImportStrategy.ts
@@ -14,11 +14,16 @@ export class DefaultAutoTileImportStrategy implements AutoTileImportStrategy {
   }
 
   getMapChipFragments() {
+    const heightChipCountPerUnit = 5
     const countX = Math.floor(this._mapChipImage.image.width / this._chipWidth)
-    const countY = Math.floor(this._mapChipImage.image.height / this._chipHeight)
+    const countY = Math.floor(
+      Math.floor(this._mapChipImage.image.height / this._chipHeight) / heightChipCountPerUnit
+    )
     const mapChipFragmentGroups: MapChipFragmentGroups = []
 
-    for (let y = 0; y < countY; y += 5) {
+    for (let cy = 0; cy < countY; cy++) {
+      const y = cy * heightChipCountPerUnit
+
       for (let x = 0; x < countX; x++) {
         const mapChipFragments: MapChipFragments = []
         mapChipFragments.push(new MapChipFragment(x, y, this._mapChipImage.id))

--- a/packages/tiled-map/tests/AutoTile/DefaultAutoTileImportStrategy.test.ts
+++ b/packages/tiled-map/tests/AutoTile/DefaultAutoTileImportStrategy.test.ts
@@ -1,0 +1,51 @@
+import { DefaultAutoTileImportStrategy } from '../../src/AutoTile/DefaultAutoTileImportStrategy'
+import { MapChipImage } from '../../src/MapChipImage'
+import { DummyImage } from '../Helpers/DummyImage'
+import { MapChipFragment } from './../../src/MapChip'
+
+Object.defineProperty(window, 'Image', {
+  value: class extends DummyImage {
+    get width() { return 70 }
+    get height() { return 360 }
+  }
+})
+
+describe('getMapChipFragments', () => {
+  it('Should return MapChipFragments', () => {
+    const image = new MapChipImage('dummy.png', 1)
+    image.loadImage()
+
+    const strategy = new DefaultAutoTileImportStrategy(image, 32, 32)
+
+    expect(strategy.getMapChipFragments()).toEqual([
+      [
+        new MapChipFragment(0, 0, 1),
+        new MapChipFragment(0, 1, 1),
+        new MapChipFragment(0, 2, 1),
+        new MapChipFragment(0, 3, 1),
+        new MapChipFragment(0, 4, 1)
+      ],
+      [
+        new MapChipFragment(1, 0, 1),
+        new MapChipFragment(1, 1, 1),
+        new MapChipFragment(1, 2, 1),
+        new MapChipFragment(1, 3, 1),
+        new MapChipFragment(1, 4, 1)
+      ],
+      [
+        new MapChipFragment(0, 5, 1),
+        new MapChipFragment(0, 6, 1),
+        new MapChipFragment(0, 7, 1),
+        new MapChipFragment(0, 8, 1),
+        new MapChipFragment(0, 9, 1)
+      ],
+      [
+        new MapChipFragment(1, 5, 1),
+        new MapChipFragment(1, 6, 1),
+        new MapChipFragment(1, 7, 1),
+        new MapChipFragment(1, 8, 1),
+        new MapChipFragment(1, 9, 1)
+      ],
+    ])
+  })
+})

--- a/packages/tiled-map/tests/Helpers/DummyImage.ts
+++ b/packages/tiled-map/tests/Helpers/DummyImage.ts
@@ -1,0 +1,18 @@
+export class DummyImage {
+  protected _onload = () => {}
+  protected _onerror = () => {}
+  protected _src = ''
+
+  constructor(_width?: number, _height?: number) {}
+
+  set src(value: string) {
+    this._src = value
+    this._onload()
+  }
+  get src() { return this._src }
+  set onload(value: () => void) { this._onload = value }
+  set onerror(value: () => void) { this._onerror = value }
+
+  get width() { return 100 }
+  get height() { return 128 }
+}

--- a/packages/tiled-map/tests/MapChipImage.test.ts
+++ b/packages/tiled-map/tests/MapChipImage.test.ts
@@ -1,23 +1,5 @@
 import { MapChipImage } from '../src/MapChipImage'
-
-class DummyImage {
-  protected _onload = () => {}
-  protected _onerror = () => {}
-  protected _src = ''
-
-  constructor(_width?: number, _height?: number) {}
-
-  set src(value: string) {
-    this._src = value
-    this._onload()
-  }
-  get src() { return this._src }
-  set onload(value: () => void) { this._onload = value }
-  set onerror(value: () => void) { this._onerror = value }
-
-  get width() { return 100 }
-  get height() { return 128 }
-}
+import { DummyImage } from './Helpers/DummyImage'
 
 describe('waitWhileLoading', () => {
   it('Should return resolved promise when the image is loaded', () => {


### PR DESCRIPTION
画像の読み取り範囲を修正することで、範囲外のオートタイルを生成しないようにする