### PR TITLE
Revert "選択されていないレイヤーを描画しない場合はマップの描画処理を呼ばない"

### DIFF
--- a/packages/map-editor-components/src/MapCanvasComponent.ts
+++ b/packages/map-editor-components/src/MapCanvasComponent.ts
@@ -45,12 +45,6 @@ export class MapCanvasComponent extends LitElement {
 
     this.setInactiveCanvasStyle()
 
-    if (value > 0 && this._mapCanvas.isRenderOnlyActiveLayer) {
-      this._mapCanvas.renderAll()
-    }
-
-    this._mapCanvas.isRenderOnlyActiveLayer = (value === 0)
-
     this.requestUpdate('inactiveLayerOpacity', oldValue);
   }
 

--- a/packages/map-editor/src/MapCanvas.ts
+++ b/packages/map-editor/src/MapCanvas.ts
@@ -30,7 +30,6 @@ export class MapCanvas implements EditorCanvas {
   private _mapChipPicker: MapChipPicker | null = null
   private _pickedCallback: PickedCallbackFn | null = null
   private _isPickFromActiveLayer = false
-  private _isRenderOnlyActiveLayer = false
 
   constructor(
   ) {
@@ -82,14 +81,6 @@ export class MapCanvas implements EditorCanvas {
     this._isPickFromActiveLayer = value
   }
 
-  get isRenderOnlyActiveLayer() {
-    return this._isRenderOnlyActiveLayer
-  }
-
-  set isRenderOnlyActiveLayer(value: boolean) {
-    this._isRenderOnlyActiveLayer = value
-  }
-
   hasActiveAutoTile() {
     return !!this._selectedAutoTile
   }
@@ -111,11 +102,7 @@ export class MapCanvas implements EditorCanvas {
   renderAll() {
     if (!this.renderable) return
     const renderer = this.renderer
-    this._canvasContexts.forEach((ctx, index) => {
-      if (this._isRenderOnlyActiveLayer && index !== this._activeLayerIndex) return
-
-      renderer.renderLayer(index, ctx)
-    })
+    this._canvasContexts.forEach((ctx, index) => renderer.renderLayer(index, ctx))
   }
 
   setCanvases(canvases: Array<HTMLCanvasElement>, secondaryCanvas: HTMLCanvasElement) {

--- a/packages/map-editor/tests/MapCanvas.test.ts
+++ b/packages/map-editor/tests/MapCanvas.test.ts
@@ -127,8 +127,6 @@ describe('#setCanvases', () => {
 describe('#renderAll', () => {
   it('Should call rendering function each layers', async () => {
     const tiledMap = new TiledMap(30, 30, 32, 32)
-    tiledMap.addLayer()
-
     const project = Projects.add(tiledMap)
     const mapCanvas = new MapCanvas()
     await mapCanvas.setProject(project)
@@ -141,28 +139,6 @@ describe('#renderAll', () => {
     mapCanvas.renderAll()
 
     expect(mapCanvas.renderer.renderLayer).toBeCalledTimes(2)
-  })
-
-  it('Should call rendering function only active layer', async () => {
-    const tiledMap = new TiledMap(30, 30, 32, 32)
-    tiledMap.addLayer()
-
-    const project = Projects.add(tiledMap)
-
-    const mapCanvas = new MapCanvas()
-    await mapCanvas.setProject(project)
-    mapCanvas.isRenderOnlyActiveLayer = true
-    mapCanvas.setActiveLayer(1)
-
-    mapCanvas.renderer.renderLayer = jest.fn()
-    mapCanvas.setCanvases([mockedCanvas, mockedCanvasLayer1] as any, mockedSecondaryCanvas as any)
-
-    // Reset renderLayer mock because renderAll is invoked by `mapCanvas.setCanvases`
-    mapCanvas.renderer.renderLayer = jest.fn()
-    mapCanvas.renderAll()
-
-    expect(mapCanvas.renderer.renderLayer).toBeCalledTimes(1)
-    expect(mapCanvas.renderer.renderLayer).toBeCalledWith(1, expect.anything())
   })
 })
 


### PR DESCRIPTION
Reverts piyoppi/pico2map#49

描画負荷の兼ね合いで追加した処理だったが、アクティブなレイヤーを切り替えたときに描画内容が更新されない不具合があるので取り下げる