### PR TITLE
Bug fix: for autotile, fix the selected area to 1px x 1px

### DIFF
--- a/packages/map-editor/src/MapCanvas.ts
+++ b/packages/map-editor/src/MapCanvas.ts
@@ -157,6 +157,7 @@ export class MapCanvas implements EditorCanvas {
 
   setAutoTile(value: AutoTile) {
     this._selectedAutoTile = value
+    this._selectedMapChipFragmentBoundarySize = {width: 1, height: 1}
   }
 
   setMapChipFragments(value: Array<MapChipFragment>) {


### PR DESCRIPTION
For AutoTile, the width and height of the selection area were not specified.