### PR TITLE
Fix an out of range error in solveOverlapped()

### DIFF
--- a/packages/tiled-colision-detector/src/TiledColisionDetector.ts
+++ b/packages/tiled-colision-detector/src/TiledColisionDetector.ts
@@ -6,6 +6,8 @@
 
 export interface TiledColisionDetectable {
   getFromChipPosition: (x: number, y: number) => ColiderTypes
+  readonly width: number
+  readonly height: number
 }
 
 export interface ColidedObject {
@@ -32,12 +34,16 @@ export type PositionDiff = {
 type Position = {x: number, y: number}
 
 export class TiledColisionDetector {
+  private coliderMapAreaWidth = 0
+  private coliderMapAreaHeight = 0
+
   constructor(
     private _data: TiledColisionDetectable,
     private _chipWidth: number,
     private _chipHeight: number
   ) {
-    
+    this.coliderMapAreaWidth = this._data.width * this._chipWidth
+    this.coliderMapAreaHeight = this._data.height * this._chipHeight
   }
 
   detect(item: ColidedObject) {
@@ -56,7 +62,7 @@ export class TiledColisionDetector {
     }
 
     for( let y = chipPositionOfItem.y1; y <= chipPositionOfItem.y2; y++ ) {
-      for( let x = chipPositionOfItem .x1; x <= chipPositionOfItem.x2; x++ ) {
+      for( let x = chipPositionOfItem.x1; x <= chipPositionOfItem.x2; x++ ) {
         if (this._data.getFromChipPosition(x, y) !== 0) {
           colidedTilePositions.push({x, y})
         }
@@ -131,6 +137,18 @@ export class TiledColisionDetector {
         clonedItem.x += overlapped.dx
       } else {
         clonedItem.y += overlapped.dy
+      }
+
+      if (clonedItem.x < 0) {
+        clonedItem.x = 0
+      } else if (clonedItem.x + clonedItem.width > this.coliderMapAreaWidth) {
+        clonedItem.x = this.coliderMapAreaWidth - clonedItem.width
+      }
+
+      if (clonedItem.y < 0) {
+        clonedItem.y = 0
+      } else if (clonedItem.y + clonedItem.height > this.coliderMapAreaHeight) {
+        clonedItem.y = this.coliderMapAreaHeight - clonedItem.height
       }
     }
 

--- a/packages/tiled-colision-detector/tests/TiledColisionDetector.test.ts
+++ b/packages/tiled-colision-detector/tests/TiledColisionDetector.test.ts
@@ -1,29 +1,25 @@
 import { TiledColisionDetector, TiledColisionDetectable, ColiderTypes } from './../src/TiledColisionDetector'
 
 class DummyColisionMap implements TiledColisionDetectable {
-  getFromChipPosition(x: number, y: number): ColiderTypes {
-    const coliderMap: Array<Array<ColiderTypes>> = [
-      //|32 |64 |96
-      [1,  1,  0],  //__32
-      [1,  0,  1],  //__64
-      [0,  1,  0],  //__96
-      [0,  0,  0],  //__128
-      [0,  0,  0],  //__160
-      [0,  1,  0],  //__192
-      [0,  0,  0],  //__224
-      [1,  0,  0],  //__256
-      [1,  0,  0],  //__288
-      [0,  0,  1],  //__320
-      [0,  0,  1],  //__352
-    ]
+  constructor(private coliderMapArray: Array<Array<ColiderTypes>>) {}
 
-    return coliderMap[y][x]
+  getFromChipPosition(x: number, y: number): ColiderTypes {
+    if (x < 0 || x >= this.coliderMapArray[0].length || y < 0 || y >= this.coliderMapArray.length) {
+      throw new Error('The position is out of range.')
+    }
+
+    return this.coliderMapArray[y][x]
+  }
+
+  get width() {
+    return this.coliderMapArray[0].length
+  }
+
+  get height() {
+    return this.coliderMapArray.length
   }
 }
 
-const colisionMap = new DummyColisionMap()
-const chipSize = {width: 32, height: 32}
-const detector = new TiledColisionDetector(colisionMap, chipSize.width, chipSize.height)
 const items = [
   {x: 30, y: 32, width: 20, height: 20},        //  0 : Overlapped: x =  2, y =  0
   {x: 32, y: 30, width: 20, height: 20},        //  1 : Overlapped: x =  0, y =  2
@@ -42,6 +38,24 @@ const items = [
 ]
 
 describe('detect', () => {
+  const detector = new TiledColisionDetector(
+    new DummyColisionMap([
+      //|32 |64 |96
+      [1,  1,  0],  //__32
+      [1,  0,  1],  //__64
+      [0,  1,  0],  //__96
+      [0,  0,  0],  //__128
+      [0,  0,  0],  //__160
+      [0,  1,  0],  //__192
+      [0,  0,  0],  //__224
+      [1,  0,  0],  //__256
+      [1,  0,  0],  //__288
+      [0,  1,  1],  //__320
+      [0,  1,  1],  //__352
+    ]),
+    32,
+    32
+  )
   it('Should return colided tile positions', () => {
     expect(detector.detect(items[0])).toEqual([{x: 0, y: 1}])
     expect(detector.detect(items[1])).toEqual([{x: 1, y: 0}])
@@ -61,6 +75,24 @@ describe('detect', () => {
 
 describe('getOverlapped', () => {
   it('Should return the overlapping amount', () => {
+    const detector = new TiledColisionDetector(
+      new DummyColisionMap([
+        //|32 |64 |96
+        [1,  1,  0],  //__32
+        [1,  0,  1],  //__64
+        [0,  1,  0],  //__96
+        [0,  0,  0],  //__128
+        [0,  0,  0],  //__160
+        [0,  1,  0],  //__192
+        [0,  0,  0],  //__224
+        [1,  0,  0],  //__256
+        [1,  0,  0],  //__288
+        [0,  1,  1],  //__320
+        [0,  1,  1],  //__352
+      ]),
+      32,
+      32
+    )
     expect(detector.getOverlapped(items[0])).toEqual({dx: 2, dy: -20, dxMax: 2, dyMax: -20})
     expect(detector.getOverlapped(items[1])).toEqual({dx: -20, dy: 2, dxMax: -20, dyMax: 2})
     expect(detector.getOverlapped(items[2])).toEqual({dx: -2, dy: -20, dxMax: -2, dyMax: -20})
@@ -80,6 +112,24 @@ describe('getOverlapped', () => {
 
 describe('solveOverlapped', () => {
   it('Should return the overlapping amount', () => {
+    const detector = new TiledColisionDetector(
+      new DummyColisionMap([
+        //|32 |64 |96
+        [1,  1,  0],  //__32
+        [1,  0,  1],  //__64
+        [0,  1,  0],  //__96
+        [0,  0,  0],  //__128
+        [0,  0,  0],  //__160
+        [0,  1,  0],  //__192
+        [0,  0,  0],  //__224
+        [1,  0,  0],  //__256
+        [1,  0,  0],  //__288
+        [0,  1,  1],  //__320
+        [0,  1,  1],  //__352
+      ]),
+      32,
+      32
+    )
     expect(detector.solveOverlapped(items[0])).toEqual({dx: 2, dy: 0})
     expect(detector.solveOverlapped(items[1])).toEqual({dx: 0, dy: 2})
     expect(detector.solveOverlapped(items[2])).toEqual({dx: -2, dy: 0})
@@ -94,5 +144,18 @@ describe('solveOverlapped', () => {
     expect(detector.solveOverlapped(items[11])).toEqual({dx: -4, dy: -2})
     expect(detector.solveOverlapped(items[12])).toEqual({dx: 0, dy: -5})
     expect(detector.solveOverlapped(items[13])).toEqual({dx: 4, dy: 0})
+  })
+
+  it('Should not reference outside the colision map', () => {
+    const detector = new TiledColisionDetector(
+      new DummyColisionMap([
+        //|32 |64
+        [1,  1],  //__32
+        [1,  1],  //__32
+      ]),
+      32,
+      32
+    )
+    expect(detector.solveOverlapped({x: 31.7, y: 4.8, width: 32, height: 32})).toEqual({dx: expect.anything(), dy: expect.anything()})
   })
 })


### PR DESCRIPTION
The solveOverlapped function may refer to an out of the collision map. In this case, an exception may be thrown.